### PR TITLE
chore: bump oh-my-customcode peer dependency to >=0.19.3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Team collaboration addon for oh-my-customcode.
 - **Language**: TypeScript (Bun runtime)
 - **Version**: 0.1.0
 - **License**: MIT
-- **Peer Dependency**: oh-my-customcode >= 0.18.0
+- **Peer Dependency**: oh-my-customcode >= 0.19.3
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Like oh-my-customcode gave you a personal agent stack, oh-my-teammates makes it 
 ## Quick Start
 
 ```bash
-# Install (requires oh-my-customcode >= 0.18.0)
+# Install (requires oh-my-customcode >= 0.19.3)
 bun add -d @oh-my-customcode/oh-my-teammates
 
 # Initialize team features on your project

--- a/README_ko.md
+++ b/README_ko.md
@@ -43,7 +43,7 @@ oh-my-customcode가 개인 에이전트 스택을 제공했다면, oh-my-teammat
 ## 빠른 시작
 
 ```bash
-# 설치 (oh-my-customcode >= 0.18.0 필요)
+# 설치 (oh-my-customcode >= 0.19.3 필요)
 bun add -d @oh-my-customcode/oh-my-teammates
 
 # 프로젝트에 팀 기능 초기화

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "*.{ts,tsx,js,jsx}": ["bunx biome check --write"]
   },
   "peerDependencies": {
-    "oh-my-customcode": ">=0.18.0"
+    "oh-my-customcode": ">=0.19.3"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.0",


### PR DESCRIPTION
Upgrade peerDep from >=0.18.0 to >=0.19.3 for compatibility with latest upstream.

Changes: package.json, README.md, README_ko.md, CLAUDE.md

Closes #27