### PR TITLE
feat: add README consistency check CI workflow

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -1,0 +1,87 @@
+name: README Consistency Check
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - 'README.md'
+      - 'README_ko.md'
+  pull_request:
+    paths:
+      - 'README.md'
+      - 'README_ko.md'
+  workflow_dispatch:
+
+jobs:
+  verify-readme-sync:
+    name: Verify README EN/KO Consistency
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Count sections in README.md and README_ko.md
+        id: count
+        run: |
+          EN_COUNT=$(grep -c "^## " README.md || echo "0")
+          KO_COUNT=$(grep -c "^## " README_ko.md || echo "0")
+
+          echo "en_count=$EN_COUNT" >> "$GITHUB_OUTPUT"
+          echo "ko_count=$KO_COUNT" >> "$GITHUB_OUTPUT"
+
+          echo "README.md sections: $EN_COUNT"
+          echo "README_ko.md sections: $KO_COUNT"
+
+      - name: Check consistency and emit warning
+        id: check
+        env:
+          EN_COUNT: ${{ steps.count.outputs.en_count }}
+          KO_COUNT: ${{ steps.count.outputs.ko_count }}
+        run: |
+          if [ "$EN_COUNT" != "$KO_COUNT" ]; then
+            echo "::warning::README section count mismatch — EN: $EN_COUNT, KO: $KO_COUNT. Please keep README.md and README_ko.md in sync."
+            echo "mismatch=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Section counts match: $EN_COUNT sections in both files."
+            echo "mismatch=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate GitHub Step Summary
+        env:
+          EN_COUNT: ${{ steps.count.outputs.en_count }}
+          KO_COUNT: ${{ steps.count.outputs.ko_count }}
+          MISMATCH: ${{ steps.check.outputs.mismatch }}
+        run: |
+          {
+            echo "## README Consistency Check"
+            echo ""
+            if [ "$MISMATCH" = "true" ]; then
+              echo "### Warning: Section Count Mismatch"
+              echo ""
+              echo "| File | Section Count |"
+              echo "|------|--------------|"
+              echo "| README.md (EN) | $EN_COUNT |"
+              echo "| README_ko.md (KO) | $KO_COUNT |"
+              echo ""
+              echo "> **Action Required**: Please update both README files to keep them in sync."
+            else
+              echo "### OK: Sections Match"
+              echo ""
+              echo "| File | Section Count |"
+              echo "|------|--------------|"
+              echo "| README.md (EN) | $EN_COUNT |"
+              echo "| README_ko.md (KO) | $KO_COUNT |"
+              echo ""
+              echo "> Both README files have the same number of sections."
+            fi
+            echo ""
+            echo "### EN Sections"
+            echo '```'
+            grep "^## " README.md | sed 's/^## /- /'
+            echo '```'
+            echo ""
+            echo "### KO Sections"
+            echo '```'
+            grep "^## " README_ko.md | sed 's/^## /- /'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- EN/KO README 섹션 카운트 비교 워크플로우 추가
- 불일치 시 `::warning::` 어노테이션으로 경고 발생
- GitHub Step Summary에 섹션별 상세 비교 표 생성

## Trigger

- `develop` 브랜치 push (README.md 또는 README_ko.md 변경 시)
- PR (README 변경 시)
- `workflow_dispatch` (수동 실행)

## Test plan

- [ ] PR 생성 시 워크플로우가 트리거되는지 확인
- [ ] EN/KO 섹션 수가 동일할 때 OK 메시지 표시 확인
- [ ] EN/KO 섹션 수가 다를 때 warning 어노테이션 표시 확인
- [ ] GitHub Step Summary가 올바르게 생성되는지 확인
- [ ] `workflow_dispatch`로 수동 실행 가능 확인

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)