### PR TITLE
fix: add bunx prefix to CLI commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Like oh-my-customcode gave you a personal agent stack, oh-my-teammates makes it 
 bun add -d @oh-my-customcode/oh-my-teammates
 
 # Initialize team features on your project
-omcustom-team init
+bunx omcustom-team init
 ```
 
 ## CLI Usage
@@ -57,7 +57,7 @@ omcustom-team init
 Bootstraps team configuration for your project:
 
 ```bash
-omcustom-team init
+bunx omcustom-team init
 ```
 
 1. **Scan** your project for languages, frameworks, and file patterns
@@ -71,10 +71,10 @@ Manage team-level tasks:
 
 ```bash
 # List all team TODOs
-omcustom-team todo list
+bunx omcustom-team todo list
 
 # Add a new team task
-omcustom-team todo add Fix API rate limiting
+bunx omcustom-team todo add Fix API rate limiting
 ```
 
 ## Dashboard
@@ -142,7 +142,7 @@ Share Claude session knowledge without external infrastructure:
 
 ```bash
 # Set up selective symlinks (per developer)
-omcustom-team link
+bunx omcustom-team link
 ```
 
 ### What Gets Shared

--- a/README_ko.md
+++ b/README_ko.md
@@ -47,7 +47,7 @@ oh-my-customcode가 개인 에이전트 스택을 제공했다면, oh-my-teammat
 bun add -d @oh-my-customcode/oh-my-teammates
 
 # 프로젝트에 팀 기능 초기화
-omcustom-team init
+bunx omcustom-team init
 ```
 
 ## CLI 사용법
@@ -57,7 +57,7 @@ omcustom-team init
 프로젝트의 팀 설정을 부트스트랩합니다:
 
 ```bash
-omcustom-team init
+bunx omcustom-team init
 ```
 
 1. **스캔** — 프로젝트의 언어, 프레임워크, 파일 패턴 분석
@@ -71,10 +71,10 @@ omcustom-team init
 
 ```bash
 # 모든 팀 TODO 목록 보기
-omcustom-team todo list
+bunx omcustom-team todo list
 
 # 새 팀 작업 추가
-omcustom-team todo add API 요청 제한 수정
+bunx omcustom-team todo add API 요청 제한 수정
 ```
 
 ## 대시보드
@@ -142,7 +142,7 @@ domains:
 
 ```bash
 # 선택적 심볼릭 링크 설정 (개발자별)
-omcustom-team link
+bunx omcustom-team link
 ```
 
 ### 공유 범위


### PR DESCRIPTION
## Summary
- Add `bunx` prefix to all CLI command examples in README.md and README_ko.md
- devDependency binaries are only in `node_modules/.bin/`, not in shell PATH
- Fixes 5 locations in each README file (Quick Start, CLI Usage, Session Sharing)

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)