### PR TITLE
feat: add CLAUDE.md template generation on team init

### DIFF
--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -100,6 +100,8 @@ describe('runCli', () => {
         teamConfigPath: '/fake/team.yaml',
         stewardsPath: '/fake/STEWARDS.yaml',
         teamDirPath: '/fake/.claude/team',
+        claudeMdPath: '/fake/CLAUDE.md',
+        claudeMdResult: { created: true, appended: false },
       });
 
       const { runCli } = await import('../cli');
@@ -109,6 +111,62 @@ describe('runCli', () => {
       expect(consoleLogs.some((l) => l.includes('backend') && l.includes('frontend'))).toBe(true);
       expect(consoleLogs.some((l) => l.includes('/fake/team.yaml'))).toBe(true);
       expect(consoleLogs.some((l) => l.includes('/fake/STEWARDS.yaml'))).toBe(true);
+
+      expect(consoleLogs.some((l) => l.includes('/fake/CLAUDE.md') && l.includes('created'))).toBe(
+        true,
+      );
+
+      initSpy.mockRestore();
+    });
+
+    it('prints CLAUDE.md appended message when team section was appended', async () => {
+      const initModule = await import('../init');
+      const initSpy = spyOn(initModule, 'initTeam').mockResolvedValue({
+        scanResult: {
+          detectedDomains: [],
+          filePatterns: {},
+          dependencies: [],
+          suggestedStewards: {},
+          analysisSkillAvailable: false,
+        },
+        teamConfigPath: '/p/team.yaml',
+        stewardsPath: '/p/STEWARDS.yaml',
+        teamDirPath: '/p/.claude/team',
+        claudeMdPath: '/p/CLAUDE.md',
+        claudeMdResult: { created: false, appended: true },
+      });
+
+      const { runCli } = await import('../cli');
+      await runCli(['init']);
+
+      expect(
+        consoleLogs.some((l) => l.includes('/p/CLAUDE.md') && l.includes('team section appended')),
+      ).toBe(true);
+
+      initSpy.mockRestore();
+    });
+
+    it('does not print CLAUDE.md message when file already had team section', async () => {
+      const initModule = await import('../init');
+      const initSpy = spyOn(initModule, 'initTeam').mockResolvedValue({
+        scanResult: {
+          detectedDomains: [],
+          filePatterns: {},
+          dependencies: [],
+          suggestedStewards: {},
+          analysisSkillAvailable: false,
+        },
+        teamConfigPath: '/p/team.yaml',
+        stewardsPath: '/p/STEWARDS.yaml',
+        teamDirPath: '/p/.claude/team',
+        claudeMdPath: '/p/CLAUDE.md',
+        claudeMdResult: { created: false, appended: false },
+      });
+
+      const { runCli } = await import('../cli');
+      await runCli(['init']);
+
+      expect(consoleLogs.some((l) => l.includes('CLAUDE.md:'))).toBe(false);
 
       initSpy.mockRestore();
     });
@@ -126,6 +184,8 @@ describe('runCli', () => {
         teamConfigPath: '/p/team.yaml',
         stewardsPath: '/p/STEWARDS.yaml',
         teamDirPath: '/p/.claude/team',
+        claudeMdPath: '/p/CLAUDE.md',
+        claudeMdResult: { created: false, appended: false },
       });
 
       const { runCli } = await import('../cli');

--- a/src/__tests__/init.test.ts
+++ b/src/__tests__/init.test.ts
@@ -2,7 +2,13 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { detectProjectName, initTeam, scaffoldTeamDir, scanProject } from '../init';
+import {
+  detectProjectName,
+  initTeam,
+  scaffoldClaudeMd,
+  scaffoldTeamDir,
+  scanProject,
+} from '../init';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -397,5 +403,97 @@ describe('initTeam', () => {
 
     const content = readFileSync(join(tmpDir, 'team.yaml'), 'utf-8');
     expect(content).toContain('cool-project');
+  });
+
+  it('returns claudeMdPath in result', async () => {
+    const result = await initTeam(tmpDir);
+    expect(result.claudeMdPath).toBe(join(tmpDir, 'CLAUDE.md'));
+  });
+
+  it('returns claudeMdResult in result', async () => {
+    const result = await initTeam(tmpDir);
+    expect(typeof result.claudeMdResult.created).toBe('boolean');
+    expect(typeof result.claudeMdResult.appended).toBe('boolean');
+  });
+
+  it('creates CLAUDE.md after initTeam', async () => {
+    await initTeam(tmpDir);
+    expect(existsSync(join(tmpDir, 'CLAUDE.md'))).toBe(true);
+  });
+});
+
+// ── scaffoldClaudeMd ──────────────────────────────────────────────────────────
+
+describe('scaffoldClaudeMd', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  it('creates CLAUDE.md when it does not exist', () => {
+    scaffoldClaudeMd(tmpDir, 'my-project');
+    expect(existsSync(join(tmpDir, 'CLAUDE.md'))).toBe(true);
+  });
+
+  it('created file contains ## Team Collaboration', () => {
+    scaffoldClaudeMd(tmpDir, 'my-project');
+    const content = readFileSync(join(tmpDir, 'CLAUDE.md'), 'utf-8');
+    expect(content).toContain('## Team Collaboration');
+  });
+
+  it('created file contains the project name', () => {
+    scaffoldClaudeMd(tmpDir, 'awesome-project');
+    const content = readFileSync(join(tmpDir, 'CLAUDE.md'), 'utf-8');
+    expect(content).toContain('awesome-project');
+  });
+
+  it('appends team section to existing CLAUDE.md without a team section', () => {
+    writeFileSync(join(tmpDir, 'CLAUDE.md'), '# Existing Project\n\nSome content.\n', 'utf-8');
+    scaffoldClaudeMd(tmpDir, 'my-project');
+    const content = readFileSync(join(tmpDir, 'CLAUDE.md'), 'utf-8');
+    expect(content).toContain('## Team Collaboration');
+  });
+
+  it('preserves existing content when appending', () => {
+    const original = '# Existing Project\n\nSome content.\n';
+    writeFileSync(join(tmpDir, 'CLAUDE.md'), original, 'utf-8');
+    scaffoldClaudeMd(tmpDir, 'my-project');
+    const content = readFileSync(join(tmpDir, 'CLAUDE.md'), 'utf-8');
+    expect(content).toContain('# Existing Project');
+    expect(content).toContain('Some content.');
+  });
+
+  it('does not modify CLAUDE.md that already has a team section', () => {
+    const original = '# Project\n\n## Team Collaboration\n\nAlready here.\n';
+    writeFileSync(join(tmpDir, 'CLAUDE.md'), original, 'utf-8');
+    scaffoldClaudeMd(tmpDir, 'my-project');
+    const content = readFileSync(join(tmpDir, 'CLAUDE.md'), 'utf-8');
+    expect(content).toBe(original);
+  });
+
+  it('returns { created: true, appended: false } when creating new file', () => {
+    const result = scaffoldClaudeMd(tmpDir, 'my-project');
+    expect(result).toEqual({ created: true, appended: false });
+  });
+
+  it('returns { created: false, appended: true } when appending to existing file', () => {
+    writeFileSync(join(tmpDir, 'CLAUDE.md'), '# Existing\n', 'utf-8');
+    const result = scaffoldClaudeMd(tmpDir, 'my-project');
+    expect(result).toEqual({ created: false, appended: true });
+  });
+
+  it('returns { created: false, appended: false } when team section already exists', () => {
+    writeFileSync(
+      join(tmpDir, 'CLAUDE.md'),
+      '# Project\n\n## Team Collaboration\n\nAlready here.\n',
+      'utf-8',
+    );
+    const result = scaffoldClaudeMd(tmpDir, 'my-project');
+    expect(result).toEqual({ created: false, appended: false });
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,11 @@ export async function runCli(args: string[]): Promise<void> {
       console.log(`Detected domains: ${result.scanResult.detectedDomains.join(', ')}`);
       console.log(`Team config: ${result.teamConfigPath}`);
       console.log(`Stewards: ${result.stewardsPath}`);
+      if (result.claudeMdResult.created) {
+        console.log(`CLAUDE.md: ${result.claudeMdPath} (created)`);
+      } else if (result.claudeMdResult.appended) {
+        console.log(`CLAUDE.md: ${result.claudeMdPath} (team section appended)`);
+      }
       break;
     }
     case 'todo': {

--- a/src/init.ts
+++ b/src/init.ts
@@ -197,6 +197,79 @@ export function scanProject(rootDir = '.'): ProjectScanResult {
   };
 }
 
+// ── CLAUDE.md scaffolding ─────────────────────────────────────────────────────
+
+/**
+ * Generate the "## Team Collaboration" section content for CLAUDE.md.
+ */
+function generateTeamSection(): string {
+  return `## Team Collaboration
+
+This project uses [oh-my-teammates](https://github.com/baekenough/oh-my-teammates) for team collaboration.
+
+### Team Files
+
+| File | Purpose |
+|------|---------|
+| \`team.yaml\` | Team member mapping and roles |
+| \`STEWARDS.yaml\` | Domain ownership assignments |
+| \`.claude/team/TODO.md\` | Shared team tasks |
+
+### Steward Delegation
+
+Code review assignments follow domain stewardship defined in \`STEWARDS.yaml\`.
+Each domain has a primary and backup steward for review routing.
+
+### Session Sharing
+
+Team sessions are shared via \`.claude/team/\`:
+- \`shared-memory/\` — Cross-team learnings
+- \`session-logs/\` — Session summaries
+- \`employees/\` — Per-member profiles
+
+### Guardian CI
+
+Harness integrity is validated on every PR targeting \`main\` or \`develop\`.
+Changes in \`.claude/\` trigger automated validation (~860ms).
+
+### Team TODO
+
+Team tasks are tracked in \`.claude/team/TODO.md\`.
+Use \`bunx omcustom-team todo list\` and \`bunx omcustom-team todo add\` to manage tasks.`;
+}
+
+/**
+ * Create or update `CLAUDE.md` in the given root directory with team collaboration content.
+ *
+ * - If `CLAUDE.md` does not exist: creates it with a project heading and the team section.
+ * - If `CLAUDE.md` exists but has no team section: appends the team section.
+ * - If `CLAUDE.md` already contains `## Team Collaboration`: leaves it untouched (idempotent).
+ *
+ * @returns `{ created, appended }` — exactly one will be `true` unless the file already had a team section.
+ */
+export function scaffoldClaudeMd(
+  rootDir = '.',
+  projectName = 'my-project',
+): { created: boolean; appended: boolean } {
+  const claudeMdPath = join(rootDir, 'CLAUDE.md');
+  const teamSection = generateTeamSection();
+
+  if (!existsSync(claudeMdPath)) {
+    writeFileSync(claudeMdPath, `# ${projectName}\n\n${teamSection}\n`, 'utf-8');
+    return { created: true, appended: false };
+  }
+
+  const existing = readFileSync(claudeMdPath, 'utf-8');
+  if (existing.includes('## Team Collaboration')) {
+    return { created: false, appended: false };
+  }
+
+  writeFileSync(claudeMdPath, `${existing.trimEnd()}\n\n${teamSection}\n`, 'utf-8');
+  return { created: false, appended: true };
+}
+
+// ── Team directory scaffolding ────────────────────────────────────────────────
+
 /**
  * Create the `.claude/team/` directory scaffold and a TODO.md template inside.
  *
@@ -241,6 +314,7 @@ export function scaffoldTeamDir(rootDir = '.', analysisSkillAvailable = false): 
  * 2. Scaffold `.claude/team/` directory with TODO.md.
  * 3. Create `team.yaml` template (if absent).
  * 4. Create `STEWARDS.yaml` draft (if absent).
+ * 5. Create or update `CLAUDE.md` with team collaboration section.
  *
  * Returns paths to the created/located files plus the scan result.
  */
@@ -249,6 +323,8 @@ export async function initTeam(rootDir = '.'): Promise<{
   teamConfigPath: string;
   stewardsPath: string;
   teamDirPath: string;
+  claudeMdPath: string;
+  claudeMdResult: { created: boolean; appended: boolean };
 }> {
   // 1. Scan project
   const scanResult = scanProject(rootDir);
@@ -269,11 +345,18 @@ export async function initTeam(rootDir = '.'): Promise<{
     Stewards.createTemplate(stewardsPath);
   }
 
+  // 5. Create or update CLAUDE.md with team collaboration section
+  const projectName = detectProjectName(rootDir);
+  const claudeMdPath = join(rootDir, 'CLAUDE.md');
+  const claudeMdResult = scaffoldClaudeMd(rootDir, projectName);
+
   return {
     scanResult,
     teamConfigPath,
     stewardsPath,
     teamDirPath: join(rootDir, '.claude', 'team'),
+    claudeMdPath,
+    claudeMdResult,
   };
 }
 

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -1,0 +1,35 @@
+# {project-name}
+
+## Team Collaboration
+
+This project uses [oh-my-teammates](https://github.com/baekenough/oh-my-teammates) for team collaboration.
+
+### Team Files
+
+| File | Purpose |
+|------|---------|
+| `team.yaml` | Team member mapping and roles |
+| `STEWARDS.yaml` | Domain ownership assignments |
+| `.claude/team/TODO.md` | Shared team tasks |
+
+### Steward Delegation
+
+Code review assignments follow domain stewardship defined in `STEWARDS.yaml`.
+Each domain has a primary and backup steward for review routing.
+
+### Session Sharing
+
+Team sessions are shared via `.claude/team/`:
+- `shared-memory/` — Cross-team learnings
+- `session-logs/` — Session summaries
+- `employees/` — Per-member profiles
+
+### Guardian CI
+
+Harness integrity is validated on every PR targeting `main` or `develop`.
+Changes in `.claude/` trigger automated validation (~860ms).
+
+### Team TODO
+
+Team tasks are tracked in `.claude/team/TODO.md`.
+Use `bunx omcustom-team todo list` and `bunx omcustom-team todo add` to manage tasks.


### PR DESCRIPTION
## Summary
- Add `scaffoldClaudeMd()` function to create or append team collaboration section to CLAUDE.md during `omcustom-team init`
- Template includes: team files reference, steward delegation, session sharing, Guardian CI, team TODO sections
- Safely handles existing CLAUDE.md files (append mode) and is idempotent
- 12 new tests added, all 189 tests passing with 99.93% coverage

## Changes
- `src/init.ts` — new `generateTeamSection()` + `scaffoldClaudeMd()` functions, `initTeam()` returns `claudeMdPath` and `claudeMdResult`
- `src/cli.ts` — display CLAUDE.md status on init
- `templates/CLAUDE.md` — reference template
- `src/__tests__/init.test.ts` — 9 tests for `scaffoldClaudeMd`
- `src/__tests__/cli.test.ts` — updated mocks + 2 new tests

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)