### PR TITLE
feat: add agent_start/agent_stop event types to SessionLogger

### DIFF
--- a/src/__tests__/session-logger.test.ts
+++ b/src/__tests__/session-logger.test.ts
@@ -214,13 +214,9 @@ describe('SessionLogger', () => {
 
     it('supports all valid event types', () => {
       const sessionId = logger.startSession('carol', 'main');
-      const types: Array<'file_change' | 'command' | 'agent_spawn' | 'error' | 'note'> = [
-        'file_change',
-        'command',
-        'agent_spawn',
-        'error',
-        'note',
-      ];
+      const types: Array<
+        'file_change' | 'command' | 'agent_spawn' | 'agent_start' | 'agent_stop' | 'error' | 'note'
+      > = ['file_change', 'command', 'agent_spawn', 'agent_start', 'agent_stop', 'error', 'note'];
       for (const type of types) {
         logger.logEvent(type, {});
       }

--- a/src/session-logger.ts
+++ b/src/session-logger.ts
@@ -18,7 +18,7 @@ export interface SessionEvent {
   id: number;
   sessionId: string;
   timestamp: string; // ISO 8601
-  type: 'file_change' | 'command' | 'agent_spawn' | 'error' | 'note';
+  type: 'file_change' | 'command' | 'agent_spawn' | 'agent_start' | 'agent_stop' | 'error' | 'note';
   data: string; // JSON string
 }
 


### PR DESCRIPTION
## Summary
- `SessionEvent.type`에 `agent_start`, `agent_stop` 이벤트 타입 추가
- oh-my-customcode v0.23.0의 SubagentStart/SubagentStop 훅 이벤트 대응
- 테스트 업데이트 완료 (200 pass, 100% coverage)

## Changes
- `src/session-logger.ts`: type union 확장 (5 → 7 types)
- `src/__tests__/session-logger.test.ts`: "supports all valid event types" 테스트 업데이트

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)