### PR TITLE
chore: update oh-my-customcode to v0.23.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "bun-types": "^1.3.10",
     "husky": "^9.1.7",
     "lint-staged": "^16.3.2",
-    "oh-my-customcode": "^0.23.0"
+    "oh-my-customcode": "^0.23.2"
   },
   "dependencies": {
     "yaml": "^2.7.0"


### PR DESCRIPTION
## Summary
- Update oh-my-customcode devDependency from `^0.23.0` to `^0.23.2`
- Closes #73

## Why
v0.23.1/v0.23.2 includes fixes for bugs we reported:
- `--dry-run` modifying CLAUDE.md (oh-my-customcode #220)
- CLAUDE.md content destruction during update (oh-my-customcode #221)

## Test plan
- [ ] `bun test` passes
- [ ] `bun install` resolves correctly