### PR TITLE
chore: update oh-my-customcode to ^0.30.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,7 +309,7 @@ Team collaboration addon for oh-my-customcode.
 ## Project Info
 
 - **Language**: TypeScript (Bun runtime)
-- **Version**: 0.4.3
+- **Version**: 0.4.4
 - **License**: MIT
 - **Peer Dependency**: oh-my-customcode >= 0.23.0
 

--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
         "bun-types": "^1.3.10",
         "husky": "^9.1.7",
         "lint-staged": "^16.3.2",
-        "oh-my-customcode": "^0.24.0",
+        "oh-my-customcode": "^0.30.0",
       },
       "peerDependencies": {
         "oh-my-customcode": ">=0.23.0",
@@ -89,7 +89,7 @@
 
     "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 
-    "oh-my-customcode": ["oh-my-customcode@0.24.0", "", { "dependencies": { "commander": "^14.0.2", "i18next": "^25.8.0", "yaml": "^2.8.2" }, "bin": { "omcustom": "dist/cli/index.js" } }, "sha512-qtgh7GXHO0L2wav4sJlKZ4dfkQ855F2GKHuKvOqGfIeqEDoXv5Jht1bIXDexXGwi41yj/lpvfOhFOm1C5aKOUQ=="],
+    "oh-my-customcode": ["oh-my-customcode@0.30.0", "", { "dependencies": { "commander": "^14.0.2", "i18next": "^25.8.0", "yaml": "^2.8.2" }, "bin": { "omcustom": "dist/cli/index.js" } }, "sha512-JpK68mMsPYfATlbYmSXrlW59LTgPqrrbmk6MpA5pJEiv0SdfULnqbb4MwwQZAhUXr5eZczTDt6a1ED1lr5KCSg=="],
 
     "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oh-my-customcode/oh-my-teammates",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Team collaboration addon for oh-my-customcode - organizational harness management",
   "type": "module",
   "main": "dist/index.js",
@@ -39,7 +39,7 @@
     "bun-types": "^1.3.10",
     "husky": "^9.1.7",
     "lint-staged": "^16.3.2",
-    "oh-my-customcode": "^0.24.0"
+    "oh-my-customcode": "^0.30.0"
   },
   "dependencies": {
     "yaml": "^2.7.0"


### PR DESCRIPTION
## Summary
- devDependency `oh-my-customcode` ^0.24.0 → ^0.30.0 업데이트
- 패키지 버전 0.4.3 → 0.4.4 범프
- No breaking changes, peerDependency (>=0.23.0) 유지

## Upstream Changes (v0.24.1 ~ v0.30.0)
- v0.24.1: Session-end memory save enforcement, HookCommand type improvement
- v0.24.2: R007/R018 rule changes, /research skill context fork fix
- v0.30.0: DDUDUDDUDU ADOPT patterns (Drift Detection, Context Budget, Confidence-Tracked Memory)

## Test plan
- [x] bun test: 200 pass, 99.94% coverage
- [x] bun run build: 성공
- [ ] CI pipeline 통과 확인

Closes #79, #80, #81