### PR TITLE
docs: enhance steward documentation and bump to v0.5.1

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture Guide — oh-my-teammates
 
-> Version 0.2.0 | Runtime: Bun | Language: TypeScript (strict mode)
+> Version 0.5.1 | Runtime: Bun | Language: TypeScript (strict mode)
 
 ## Overview
 
@@ -13,43 +13,53 @@
 - **Project scaffolding** — automated project scanning and configuration bootstrapping
 - **CLI** — `omcustom-team` binary for day-to-day team operations
 - **Dashboard** — SvelteKit visualization layer for the team's agent/skill/rule inventory
+- **Agent recommendation** — 4-layer confidence scoring engine for tech stack analysis (`recommender.ts`)
+- **Report generation** — static HTML reports aggregating team, session, steward, and TODO data (`report.ts`)
 
 ## System Architecture
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│                       omcustom-team CLI                         │
-│                           (cli.ts)                              │
-│         omcustom-team init   |   omcustom-team todo             │
-├──────────────────────────────┬──────────────────────────────────┤
-│                              │                                  │
-│  ┌───────────────────┐       │    ┌───────────────────────┐    │
-│  │    TeamConfig     │       │    │    SessionLogger       │    │
-│  │  (team-config.ts) │       │    │  (session-logger.ts)  │    │
-│  │                   │       │    │    bun:sqlite WAL      │    │
-│  │  team.yaml CRUD   │       │    │  sessions + events    │    │
-│  └───────────────────┘       │    └───────────────────────┘    │
-│                              │                                  │
-│  ┌───────────────────┐       │    ┌───────────────────────┐    │
-│  │     Stewards      │◄──────┘    │      TeamTodo         │    │
-│  │   (stewards.ts)   │            │   (team-todo.ts)      │    │
-│  │                   │◄───────────│                       │    │
-│  │ STEWARDS.yaml +   │  autoAssign│  TODO.md parsing +    │    │
-│  │ CODEOWNERS gen    │            │  priority management  │    │
-│  └───────────────────┘            └───────────────────────┘    │
-│                                                                 │
-│  ┌─────────────────────────────────────────────────────────┐   │
-│  │                        init.ts                          │   │
-│  │   scanProject() → scaffoldTeamDir() → createTemplate()  │   │
-│  │   Detects: languages, frameworks, dependency manifests  │   │
-│  └─────────────────────────────────────────────────────────┘   │
-├─────────────────────────────────────────────────────────────────┤
-│                     Public API (index.ts)                       │
-│     TeamConfig | SessionLogger | Stewards | TeamTodo            │
-├─────────────────────────────────────────────────────────────────┤
-│                    SvelteKit Dashboard                          │
-│          dashboard/ → adapter-static → GitHub Pages             │
-└─────────────────────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────────────────┐
+│                          omcustom-team CLI                           │
+│                              (cli.ts)                                │
+│      init  │  todo  │  recommend  │  report  │  status               │
+├────────────┴────────┴─────────────┴──────────┴───────────────────────┤
+│                                                                       │
+│  ┌─────────────┐  ┌──────────┐  ┌───────────────┐  ┌─────────────┐  │
+│  │ TeamConfig  │  │ Stewards │  │ SessionLogger │  │  TeamTodo   │  │
+│  │ team.yaml   │  │STEWARDS  │  │  bun:sqlite   │  │  TODO.md    │  │
+│  │ CRUD +      │  │.yaml +   │  │  WAL mode     │  │  priority + │  │
+│  │ validation  │←→│CODEOWNERS│←─│  sessions +   │  │  auto-      │  │
+│  └─────────────┘  │generation│  │  events       │  │  assign     │──┤
+│                    └─────┬───┘  └───────────────┘  └─────────────┘  │
+│                          │              │                  │          │
+│                          │              ▼                  │          │
+│  ┌─────────────┐         │    ┌───────────────┐           │          │
+│  │ Recommender │         │    │ReportGenerator│◄──────────┘          │
+│  │ 4-layer     │         │    │ HTML output   │                      │
+│  │ scoring     │         └───►│ aggregates    │                      │
+│  │             │              │ all modules   │                      │
+│  └──────┬──────┘              └───────────────┘                      │
+│         │                                                             │
+│  ┌──────┴──────┐  ┌──────────────┐                                   │
+│  │AgentCatalog │  │ManifestParser│                                   │
+│  │ 41 agents   │  │ package.json │                                   │
+│  │ detection   │  │ go.mod, etc  │                                   │
+│  │ rules       │  │              │                                   │
+│  └─────────────┘  └──────────────┘                                   │
+│                                                                       │
+│  ┌───────────────────────────────────────────────────────────────┐   │
+│  │                          init.ts                              │   │
+│  │   scanProject() → scaffoldTeamDir() → scaffoldClaudeMd()      │   │
+│  └───────────────────────────────────────────────────────────────┘   │
+├───────────────────────────────────────────────────────────────────────┤
+│                        Public API (index.ts)                          │
+│  TeamConfig │ SessionLogger │ Stewards │ TeamTodo │ Recommender       │
+│  ReportGenerator │ AgentCatalog │ ManifestParser                      │
+├───────────────────────────────────────────────────────────────────────┤
+│                       SvelteKit Dashboard                             │
+│             dashboard/ → adapter-static → GitHub Pages                │
+└───────────────────────────────────────────────────────────────────────┘
 ```
 
 ## Core Modules
@@ -200,6 +210,100 @@ interface TodoItem {
 
 ---
 
+## Steward Concept Deep Dive
+
+### Purpose
+
+Stewards answer the fundamental team question: **"Who is responsible for this code?"**
+
+Rather than managing CODEOWNERS manually at the file level, Stewards introduce a **domain abstraction layer**. You declare ownership at the domain level, and the system handles file-to-owner mapping automatically.
+
+### Core Value Proposition
+
+| Aspect | Traditional (CODEOWNERS) | Steward System |
+|--------|--------------------------|----------------|
+| Granularity | File/directory paths | **Domain** (8 semantic categories) |
+| Maintenance | Manual edits, easily outdated | Declarative YAML, auto-generates CODEOWNERS |
+| Task assignment | Manual per-task | Auto-assign via domain lookup |
+| Discoverability | Grep through CODEOWNERS | `findStewardForFile(path)` API |
+| Coverage visibility | None | Report highlights unowned domains |
+
+### How the Mapping Works
+
+```
+┌──────────────────┐     ┌──────────────────┐     ┌──────────────────┐
+│   File Changed    │     │   Domain Match    │     │  Steward Found   │
+│                   │     │                   │     │                  │
+│ src/api/auth.ts   │────►│ backend           │────►│ primary: alice   │
+│                   │ glob│ (src/api/**)       │     │ backup:  bob     │
+└──────────────────┘match └──────────────────┘     └──────────────────┘
+```
+
+The `findStewardForFile()` method:
+1. Iterates through all domains in `STEWARDS.yaml`
+2. For each domain, tests the file path against every glob pattern in `paths[]`
+3. Returns the first matching domain's `primary` and `backup` steward
+4. Returns `undefined` if no domain claims the file (coverage gap)
+
+### Integration Points
+
+```
+STEWARDS.yaml ─────────────────────────────────┐
+     │                                          │
+     ├─► generateCodeowners()                   │
+     │     └─► .github/CODEOWNERS               │
+     │           └─► GitHub auto-assigns         │
+     │               PR reviewers                │
+     │                                          │
+     ├─► TeamTodo.autoAssign()                  │
+     │     └─► TODO items with domain but       │
+     │         no assignee get primary steward   │
+     │                                          │
+     ├─► ReportGenerator                        │
+     │     └─► Coverage gap analysis            │
+     │         (domains with no steward)         │
+     │                                          │
+     └─► findStewardForFile(path)               │
+           └─► Runtime query: "who owns this?"  │
+```
+
+### Practical Example
+
+Given this `STEWARDS.yaml`:
+
+```yaml
+stewards:
+  version: "1.0"
+  domains:
+    frontend:
+      primary: carol
+      backup: dave
+      paths:
+        - src/components/**
+        - "**/*.svelte"
+        - "**/*.tsx"
+    backend:
+      primary: alice
+      backup: bob
+      paths:
+        - src/api/**
+        - src/server/**
+```
+
+**Scenario 1: PR Review**
+A PR modifies `src/api/auth.ts` → Stewards generates CODEOWNERS → GitHub assigns `@alice` and `@bob` as reviewers automatically.
+
+**Scenario 2: TODO Auto-Assignment**
+```
+Before: ## team: [P0] Fix auth bug — (backend)     ← no assignee
+After:  ## team: [P0] Fix auth bug — @alice (backend) ← auto-assigned
+```
+
+**Scenario 3: Coverage Gap Detection**
+If `data-engineering` domain has `primary: null`, the report flags it as an unowned domain requiring attention.
+
+---
+
 ### init (`src/init.ts`)
 
 Project scanning and bootstrapping entry point.
@@ -236,6 +340,60 @@ Entry point for the `omcustom-team` binary, exported from `dist/cli.js`.
 
 **Exit codes:** Exits with code `1` on missing required arguments or missing TODO.md when `list` is called before `init`.
 
+---
+
+### Recommender (`src/recommender.ts`)
+
+Scans a project directory and produces ranked agent recommendations based on tech stack analysis.
+
+**Key types:**
+
+```typescript
+interface AgentRecommendation {
+  agent: string;         // Agent name from catalog
+  category: AgentCategory;
+  description: string;
+  confidence: number;    // 0.0 - 1.0
+  reasons: string[];     // Human-readable match reasons
+}
+```
+
+**4-layer confidence scoring:**
+
+| Layer | Signal | Max Confidence | Example |
+|-------|--------|---------------|---------|
+| 1. File extensions | `*.ts`, `*.py`, `*.go` | 0.5 | "42 .ts files found" |
+| 2. Config files | `tsconfig.json`, `Cargo.toml` | 0.8 | "tsconfig.json found" |
+| 3. Directory patterns | `dags/`, `migrations/` | 0.6 | "dags/ directory found" |
+| 4. Manifest dependencies | `react` in package.json | 0.9 | "react, next in package.json" |
+
+**Scoring algorithm:** Each layer produces a confidence score. The final confidence is `max(all layer scores)`, capped at 1.0. Higher layers (dependencies) override lower layers (extensions) when present.
+
+**Data flow:** `scanFiles()` → `parseManifests()` → `scoreAgent()` per catalog entry → sort by confidence → filter by `minConfidence`
+
+---
+
+### ReportGenerator (`src/report.ts`)
+
+Aggregates data from all core modules and produces a self-contained static HTML report.
+
+**Data sources:**
+
+| Source | Data Collected |
+|--------|---------------|
+| `TeamConfig` | Team name, member list |
+| `Stewards` | Domain ownership map, coverage gaps |
+| `TeamTodo` | Open/completed items, priority distribution |
+| `SessionLogger` | Recent sessions, event stats, user activity |
+
+**Report sections:** Team overview, domain stewardship matrix, TODO summary, session activity, coverage gap analysis.
+
+**Output:** Single `.html` file at `.claude/team/report.html` (configurable). No external dependencies — all CSS/JS is inlined.
+
+**Graceful degradation:** Each data source is independently collected. If `team.yaml` is missing, the report still generates with available data. No single missing file blocks report generation.
+
+---
+
 ## Data Flow
 
 ```
@@ -271,6 +429,26 @@ Stewards.writeCodeowners()
   │
   ├─ generateCodeowners() → format each domain's paths + owners
   └─ write to .github/CODEOWNERS
+
+Recommender.recommend()
+  │
+  ├─ scanFiles()
+  │     walk project tree → collect extensions, config files, directories
+  │
+  ├─ parseManifests()
+  │     detect package.json, go.mod, etc. → extract dependencies
+  │
+  └─ scoreAgent() × N catalog entries
+        4-layer scoring → sort by confidence → return recommendations
+
+ReportGenerator.generate()
+  │
+  ├─ collectTeamConfig()    → team.yaml data
+  ├─ collectDomains()       → STEWARDS.yaml data
+  ├─ collectTodos()         → TODO.md items
+  ├─ collectSessionData()   → SQLite session stats
+  ├─ computeCoverageGaps()  → unowned domains
+  └─ generateReportHtml()   → single HTML file output
 ```
 
 ## Dashboard

--- a/ARCHITECTURE_ko.md
+++ b/ARCHITECTURE_ko.md
@@ -1,6 +1,6 @@
 # 아키텍처 가이드 — oh-my-teammates
 
-> Version 0.2.0 | Runtime: Bun | Language: TypeScript (strict mode)
+> Version 0.5.1 | Runtime: Bun | Language: TypeScript (strict mode)
 
 ## 개요
 
@@ -13,43 +13,53 @@
 - **프로젝트 스캐폴딩** — 자동 프로젝트 스캔 및 설정 부트스트랩
 - **CLI** — 일상적인 팀 운영을 위한 `omcustom-team` 바이너리
 - **대시보드** — 팀의 에이전트/스킬/규칙 인벤토리를 위한 SvelteKit 시각화 레이어
+- **에이전트 추천** — 기술 스택 분석을 위한 4계층 신뢰도 점수 엔진 (`recommender.ts`)
+- **리포트 생성** — 팀, 세션, 스튜어드, TODO 데이터를 집계하는 정적 HTML 리포트 (`report.ts`)
 
 ## 시스템 아키텍처
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│                       omcustom-team CLI                         │
-│                           (cli.ts)                              │
-│         omcustom-team init   |   omcustom-team todo             │
-├──────────────────────────────┬──────────────────────────────────┤
-│                              │                                  │
-│  ┌───────────────────┐       │    ┌───────────────────────┐    │
-│  │    TeamConfig     │       │    │    SessionLogger       │    │
-│  │  (team-config.ts) │       │    │  (session-logger.ts)  │    │
-│  │                   │       │    │    bun:sqlite WAL      │    │
-│  │  team.yaml CRUD   │       │    │  sessions + events    │    │
-│  └───────────────────┘       │    └───────────────────────┘    │
-│                              │                                  │
-│  ┌───────────────────┐       │    ┌───────────────────────┐    │
-│  │     Stewards      │◄──────┘    │      TeamTodo         │    │
-│  │   (stewards.ts)   │            │   (team-todo.ts)      │    │
-│  │                   │◄───────────│                       │    │
-│  │ STEWARDS.yaml +   │  autoAssign│  TODO.md 파싱 +       │    │
-│  │ CODEOWNERS 생성   │            │  우선순위 관리         │    │
-│  └───────────────────┘            └───────────────────────┘    │
-│                                                                 │
-│  ┌─────────────────────────────────────────────────────────┐   │
-│  │                        init.ts                          │   │
-│  │   scanProject() → scaffoldTeamDir() → createTemplate()  │   │
-│  │   감지: 언어, 프레임워크, 의존성 매니페스트               │   │
-│  └─────────────────────────────────────────────────────────┘   │
-├─────────────────────────────────────────────────────────────────┤
-│                   공개 API (index.ts)                           │
-│     TeamConfig | SessionLogger | Stewards | TeamTodo            │
-├─────────────────────────────────────────────────────────────────┤
-│                    SvelteKit 대시보드                           │
-│          dashboard/ → adapter-static → GitHub Pages             │
-└─────────────────────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────────────────┐
+│                          omcustom-team CLI                           │
+│                              (cli.ts)                                │
+│      init  │  todo  │  recommend  │  report  │  status               │
+├────────────┴────────┴─────────────┴──────────┴───────────────────────┤
+│                                                                       │
+│  ┌─────────────┐  ┌──────────┐  ┌───────────────┐  ┌─────────────┐  │
+│  │ TeamConfig  │  │ Stewards │  │ SessionLogger │  │  TeamTodo   │  │
+│  │ team.yaml   │  │STEWARDS  │  │  bun:sqlite   │  │  TODO.md    │  │
+│  │ CRUD +      │  │.yaml +   │  │  WAL mode     │  │  priority + │  │
+│  │ validation  │←→│CODEOWNERS│←─│  sessions +   │  │  auto-      │  │
+│  └─────────────┘  │generation│  │  events       │  │  assign     │──┤
+│                    └─────┬───┘  └───────────────┘  └─────────────┘  │
+│                          │              │                  │          │
+│                          │              ▼                  │          │
+│  ┌─────────────┐         │    ┌───────────────┐           │          │
+│  │ Recommender │         │    │ReportGenerator│◄──────────┘          │
+│  │ 4-layer     │         │    │ HTML output   │                      │
+│  │ scoring     │         └───►│ aggregates    │                      │
+│  │             │              │ all modules   │                      │
+│  └──────┬──────┘              └───────────────┘                      │
+│         │                                                             │
+│  ┌──────┴──────┐  ┌──────────────┐                                   │
+│  │AgentCatalog │  │ManifestParser│                                   │
+│  │ 41 agents   │  │ package.json │                                   │
+│  │ detection   │  │ go.mod, etc  │                                   │
+│  │ rules       │  │              │                                   │
+│  └─────────────┘  └──────────────┘                                   │
+│                                                                       │
+│  ┌───────────────────────────────────────────────────────────────┐   │
+│  │                          init.ts                              │   │
+│  │   scanProject() → scaffoldTeamDir() → scaffoldClaudeMd()      │   │
+│  └───────────────────────────────────────────────────────────────┘   │
+├───────────────────────────────────────────────────────────────────────┤
+│                        Public API (index.ts)                          │
+│  TeamConfig │ SessionLogger │ Stewards │ TeamTodo │ Recommender       │
+│  ReportGenerator │ AgentCatalog │ ManifestParser                      │
+├───────────────────────────────────────────────────────────────────────┤
+│                       SvelteKit 대시보드                              │
+│             dashboard/ → adapter-static → GitHub Pages                │
+└───────────────────────────────────────────────────────────────────────┘
 ```
 
 ## 핵심 모듈
@@ -200,6 +210,100 @@ interface TodoItem {
 
 ---
 
+## 스튜어드 개념 심층 분석
+
+### 목적
+
+스튜어드는 팀의 근본적인 질문에 답합니다: **"이 코드의 책임자는 누구인가?"**
+
+CODEOWNERS를 파일 수준에서 수동으로 관리하는 대신, 스튜어드는 **도메인 추상화 레이어**를 도입합니다. 도메인 수준에서 소유권을 선언하면, 시스템이 파일-소유자 매핑을 자동으로 처리합니다.
+
+### 핵심 가치 제안
+
+| 관점 | 기존 방식 (CODEOWNERS) | 스튜어드 시스템 |
+|------|----------------------|----------------|
+| 세분화 | 파일/디렉토리 경로 | **도메인** (8개 시맨틱 카테고리) |
+| 유지보수 | 수동 편집, 쉽게 오래됨 | 선언적 YAML, CODEOWNERS 자동 생성 |
+| 작업 할당 | 작업별 수동 할당 | 도메인 조회로 자동 할당 |
+| 탐색성 | CODEOWNERS를 grep | `findStewardForFile(path)` API |
+| 커버리지 가시성 | 없음 | 리포트에서 미할당 도메인 강조 |
+
+### 매핑 작동 방식
+
+```
+┌──────────────────┐     ┌──────────────────┐     ┌──────────────────┐
+│   파일 변경       │     │   도메인 매치      │     │  스튜어드 확인    │
+│                   │     │                   │     │                  │
+│ src/api/auth.ts   │────►│ backend           │────►│ primary: alice   │
+│                   │ glob│ (src/api/**)       │     │ backup:  bob     │
+└──────────────────┘매치  └──────────────────┘     └──────────────────┘
+```
+
+`findStewardForFile()` 메서드:
+1. `STEWARDS.yaml`의 모든 도메인을 순회
+2. 각 도메인에 대해 파일 경로를 `paths[]`의 모든 glob 패턴과 비교
+3. 첫 번째로 매칭되는 도메인의 `primary`와 `backup` 스튜어드 반환
+4. 매칭되는 도메인이 없으면 `undefined` 반환 (커버리지 갭)
+
+### 통합 지점
+
+```
+STEWARDS.yaml ─────────────────────────────────┐
+     │                                          │
+     ├─► generateCodeowners()                   │
+     │     └─► .github/CODEOWNERS               │
+     │           └─► GitHub가 자동으로           │
+     │               PR 리뷰어 지정              │
+     │                                          │
+     ├─► TeamTodo.autoAssign()                  │
+     │     └─► 도메인은 있지만 담당자 없는       │
+     │         TODO 항목에 primary 스튜어드 할당  │
+     │                                          │
+     ├─► ReportGenerator                        │
+     │     └─► 커버리지 갭 분석                  │
+     │         (스튜어드 없는 도메인)             │
+     │                                          │
+     └─► findStewardForFile(path)               │
+           └─► 런타임 조회: "이 파일 소유자?"    │
+```
+
+### 실제 예시
+
+다음 `STEWARDS.yaml`이 주어졌을 때:
+
+```yaml
+stewards:
+  version: "1.0"
+  domains:
+    frontend:
+      primary: carol
+      backup: dave
+      paths:
+        - src/components/**
+        - "**/*.svelte"
+        - "**/*.tsx"
+    backend:
+      primary: alice
+      backup: bob
+      paths:
+        - src/api/**
+        - src/server/**
+```
+
+**시나리오 1: PR 리뷰**
+PR이 `src/api/auth.ts`를 수정 → Stewards가 CODEOWNERS 생성 → GitHub이 `@alice`와 `@bob`을 리뷰어로 자동 지정.
+
+**시나리오 2: TODO 자동 할당**
+```
+전: ## team: [P0] Fix auth bug — (backend)     ← 담당자 없음
+후: ## team: [P0] Fix auth bug — @alice (backend) ← 자동 할당됨
+```
+
+**시나리오 3: 커버리지 갭 감지**
+`data-engineering` 도메인의 `primary: null`이면, 리포트에서 주의가 필요한 미할당 도메인으로 표시합니다.
+
+---
+
 ### init (`src/init.ts`)
 
 프로젝트 스캔 및 부트스트랩 진입점입니다.
@@ -236,6 +340,60 @@ interface TodoItem {
 
 **종료 코드:** 필수 인수 누락 또는 `init` 전에 `list` 호출 시 코드 `1`로 종료.
 
+---
+
+### Recommender (`src/recommender.ts`)
+
+프로젝트 디렉토리를 스캔하고 기술 스택 분석을 기반으로 순위가 매겨진 에이전트 추천 목록을 생성합니다.
+
+**주요 타입:**
+
+```typescript
+interface AgentRecommendation {
+  agent: string;         // Agent name from catalog
+  category: AgentCategory;
+  description: string;
+  confidence: number;    // 0.0 - 1.0
+  reasons: string[];     // Human-readable match reasons
+}
+```
+
+**4계층 신뢰도 점수:**
+
+| 계층 | 신호 | 최대 신뢰도 | 예시 |
+|------|------|------------|------|
+| 1. 파일 확장자 | `*.ts`, `*.py`, `*.go` | 0.5 | "42 .ts files found" |
+| 2. 설정 파일 | `tsconfig.json`, `Cargo.toml` | 0.8 | "tsconfig.json found" |
+| 3. 디렉토리 패턴 | `dags/`, `migrations/` | 0.6 | "dags/ directory found" |
+| 4. 매니페스트 의존성 | `react` in package.json | 0.9 | "react, next in package.json" |
+
+**점수 알고리즘:** 각 계층이 신뢰도 점수를 생성합니다. 최종 신뢰도는 `max(모든 계층 점수)`이며 1.0으로 제한됩니다. 상위 계층(의존성)이 존재하면 하위 계층(확장자)을 덮어씁니다.
+
+**데이터 흐름:** `scanFiles()` → `parseManifests()` → 카탈로그 항목별 `scoreAgent()` → 신뢰도 순 정렬 → `minConfidence`로 필터링
+
+---
+
+### ReportGenerator (`src/report.ts`)
+
+모든 핵심 모듈의 데이터를 집계하여 독립형 정적 HTML 리포트를 생성합니다.
+
+**데이터 소스:**
+
+| 소스 | 수집 데이터 |
+|------|------------|
+| `TeamConfig` | 팀 이름, 멤버 목록 |
+| `Stewards` | 도메인 소유권 맵, 커버리지 갭 |
+| `TeamTodo` | 미완료/완료 항목, 우선순위 분포 |
+| `SessionLogger` | 최근 세션, 이벤트 통계, 사용자 활동 |
+
+**리포트 섹션:** 팀 개요, 도메인 스튜어드십 매트릭스, TODO 요약, 세션 활동, 커버리지 갭 분석.
+
+**출력:** `.claude/team/report.html`에 단일 `.html` 파일 생성 (설정 가능). 외부 의존성 없음 — 모든 CSS/JS가 인라인으로 포함됩니다.
+
+**점진적 성능 저하:** 각 데이터 소스는 독립적으로 수집됩니다. `team.yaml`이 없어도 사용 가능한 데이터로 리포트를 생성합니다. 단일 파일 누락이 리포트 생성을 막지 않습니다.
+
+---
+
 ## 데이터 흐름
 
 ```
@@ -271,6 +429,26 @@ Stewards.writeCodeowners()
   │
   ├─ generateCodeowners() → 각 도메인의 경로 + 소유자 포맷
   └─ .github/CODEOWNERS에 작성
+
+Recommender.recommend()
+  │
+  ├─ scanFiles()
+  │     walk project tree → collect extensions, config files, directories
+  │
+  ├─ parseManifests()
+  │     detect package.json, go.mod, etc. → extract dependencies
+  │
+  └─ scoreAgent() × N catalog entries
+        4-layer scoring → sort by confidence → return recommendations
+
+ReportGenerator.generate()
+  │
+  ├─ collectTeamConfig()    → team.yaml data
+  ├─ collectDomains()       → STEWARDS.yaml data
+  ├─ collectTodos()         → TODO.md items
+  ├─ collectSessionData()   → SQLite session stats
+  ├─ computeCoverageGaps()  → unowned domains
+  └─ generateReportHtml()   → single HTML file output
 ```
 
 ## 대시보드

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,7 +309,7 @@ Team collaboration addon for oh-my-customcode.
 ## Project Info
 
 - **Language**: TypeScript (Bun runtime)
-- **Version**: 0.4.5
+- **Version**: 0.5.1
 - **License**: MIT
 - **Peer Dependency**: oh-my-customcode >= 0.23.0
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Like oh-my-customcode gave you a personal agent stack, oh-my-teammates makes it 
 | `stewards.ts` | `STEWARDS.yaml` management with 8-domain model and CODEOWNERS generation |
 | `init.ts` | Project scanning, dependency analysis, and team configuration scaffolding |
 | `team-todo.ts` | Team-level task management with priority levels and steward-based auto-assignment |
+| `recommender.ts` | Project scanning engine with 4-layer confidence scoring for agent recommendations |
+| `report.ts` | Static HTML report generator aggregating team, steward, session, and TODO data |
 | `cli.ts` | `omcustom-team init` and `omcustom-team todo` CLI commands |
 | Dashboard | SvelteKit-based agent/skill/rule/guide visualization with dark mode and mobile support |
 
@@ -39,6 +41,66 @@ Like oh-my-customcode gave you a personal agent stack, oh-my-teammates makes it 
 | **Team TODO** | Shared task management linked to stewards and issues |
 | **Quality Metrics** | Rule Adherence Rate (RAR) tracking, target 98% |
 | **Adaptive Expansion** | Auto-detect tech stack changes and recommend new agents/skills |
+| **Agent Recommender** | Scan project structure and recommend relevant agents based on tech stack |
+| **HTML Report** | Aggregate team data into a static dashboard report |
+
+## How Stewards Work
+
+Stewards are **domain guardians** — they declare "who is responsible for what" across your codebase. Instead of manually editing `.github/CODEOWNERS`, you define ownership at the **domain level** in `STEWARDS.yaml`.
+
+### The Problem Stewards Solve
+
+| Without Stewards | With Stewards |
+|------------------|---------------|
+| Manually edit `.github/CODEOWNERS` per file | Define ownership per **domain** → CODEOWNERS auto-generated |
+| "Who should review this PR?" → ask around | `findStewardForFile("src/api/auth.ts")` → `alice` |
+| TODO tasks manually assigned | Domain-based auto-assignment via `autoAssign()` |
+| No visibility into coverage gaps | Report shows unowned domains |
+
+### How It Works
+
+```
+STEWARDS.yaml                        .github/CODEOWNERS
+┌──────────────────────┐             ┌──────────────────────────┐
+│ domains:             │             │ # Auto-generated          │
+│   frontend:          │  ────────►  │ /src/components/** @carol │
+│     primary: carol   │  generate   │ /**/*.svelte @carol @dave │
+│     backup: dave     │  Codeowners │                           │
+│     paths:           │             │ /src/api/** @alice @bob   │
+│       - src/comp/**  │             └──────────────────────────┘
+│       - **/*.svelte  │
+│   backend:           │             TODO.md (auto-assign)
+│     primary: alice   │             ┌──────────────────────────┐
+│     backup: bob      │  ────────►  │ [P0] Fix auth — @alice   │
+│     paths:           │  autoAssign │   (backend domain)       │
+│       - src/api/**   │             │ [P1] Update UI — @carol  │
+└──────────────────────┘             │   (frontend domain)      │
+                                     └──────────────────────────┘
+```
+
+### File → Domain → Steward Mapping
+
+When a file is changed, Stewards traces the chain:
+
+```
+src/components/Button.tsx → frontend domain → carol (primary), dave (backup)
+dags/daily_etl.py        → data-engineering  → dave (primary)
+Dockerfile               → infrastructure    → eve (primary)
+src/api/auth.ts          → backend domain    → alice (primary), bob (backup)
+```
+
+### 8 Default Domains
+
+| Domain | Scope | Example Patterns |
+|--------|-------|-----------------|
+| `languages` | Language-specific code | `**/*.ts`, `**/*.py`, `**/*.go` |
+| `frontend` | UI components & frameworks | `src/components/**`, `**/*.svelte` |
+| `backend` | Server & API code | `src/api/**`, `routes/**` |
+| `data-engineering` | Pipelines & DAGs | `dags/**`, `pipelines/**` |
+| `infrastructure` | Deploy & CI/CD | `Dockerfile`, `terraform/**` |
+| `database` | Schema & migrations | `**/*.sql`, `migrations/**` |
+| `quality` | Tests & specs | `**/*.test.ts`, `__tests__/**` |
+| `documentation` | Docs & guides | `docs/**`, `**/*.md` |
 
 ## Quick Start
 
@@ -76,6 +138,16 @@ bunx omcustom-team todo list
 # Add a new team task
 bunx omcustom-team todo add Fix API rate limiting
 ```
+
+### `omcustom-team recommend`
+
+Scan your project and recommend agents:
+
+```bash
+bunx omcustom-team recommend
+```
+
+Analyzes file extensions, config files, directory patterns, and manifest dependencies to suggest the most relevant oh-my-customcode agents for your tech stack.
 
 ## Dashboard
 
@@ -227,9 +299,9 @@ bun run build        # Build for production
 | Phase | Feature | Status |
 |-------|---------|--------|
 | V1 | Guardian CI, Session Logging, Stewards, Team TODO | **Shipped (v0.2.0)** |
-| V1.5 | Static HTML report (`omcustom-team report`) | Planned |
-| V2 | Dashboard enhancements — ontology graph, session timeline, RAR metrics | Planned |
-| V3 | Adaptive Expansion -- auto-detect and recommend | Planned |
+| V1.5 | Static HTML report (`omcustom-team report`) | **Shipped (v0.5.0)** |
+| V2 | Dashboard enhancements — ontology graph, session timeline, RAR metrics | **Shipped (v0.5.0)** |
+| V3 | Adaptive Expansion -- auto-detect and recommend | **Shipped (v0.5.0)** |
 
 ## Related
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -26,6 +26,8 @@ oh-my-customcode가 개인 에이전트 스택을 제공했다면, oh-my-teammat
 | `stewards.ts` | `STEWARDS.yaml` 관리, 8도메인 모델, CODEOWNERS 생성 |
 | `init.ts` | 프로젝트 스캔, 의존성 분석, 팀 설정 스캐폴딩 |
 | `team-todo.ts` | 우선순위 레벨 및 스튜어드 기반 자동 할당 팀 작업 관리 |
+| `recommender.ts` | 에이전트 추천을 위한 4계층 신뢰도 점수 기반 프로젝트 스캔 엔진 |
+| `report.ts` | 팀, 스튜어드, 세션, TODO 데이터를 집계하는 정적 HTML 리포트 생성기 |
 | `cli.ts` | `omcustom-team init` 및 `omcustom-team todo` CLI 명령어 |
 | 대시보드 | SvelteKit 기반 에이전트/스킬/규칙/가이드 시각화, 다크모드 및 모바일 지원 |
 
@@ -39,6 +41,66 @@ oh-my-customcode가 개인 에이전트 스택을 제공했다면, oh-my-teammat
 | **팀 TODO** | 스튜어드 및 이슈와 연동된 공유 작업 관리 |
 | **품질 메트릭** | Rule Adherence Rate (RAR) 추적, 목표 98% |
 | **적응형 확장** | 기술 스택 변화 자동 감지 후 새 에이전트/스킬 추천 |
+| **에이전트 추천** | 프로젝트 구조를 스캔하여 기술 스택에 맞는 에이전트 추천 |
+| **HTML 리포트** | 팀 데이터를 정적 대시보드 리포트로 집계 |
+
+## 스튜어드 작동 방식
+
+스튜어드는 **도메인 관리인**입니다 — 코드베이스 전반에 걸쳐 "누가 무엇을 책임지는가"를 선언합니다. `.github/CODEOWNERS`를 수동으로 편집하는 대신, `STEWARDS.yaml`에서 **도메인 단위**로 소유권을 정의합니다.
+
+### 스튜어드가 해결하는 문제
+
+| 스튜어드 없이 | 스튜어드 사용 시 |
+|---------------|-----------------|
+| `.github/CODEOWNERS`를 파일별 수동 편집 | **도메인** 단위로 소유권 정의 → CODEOWNERS 자동 생성 |
+| "이 PR 누가 리뷰해야 해?" → 물어보기 | `findStewardForFile("src/api/auth.ts")` → `alice` |
+| TODO 작업 수동 할당 | `autoAssign()`으로 도메인 기반 자동 할당 |
+| 커버리지 갭 파악 불가 | 리포트에서 소유자 없는 도메인 표시 |
+
+### 작동 원리
+
+```
+STEWARDS.yaml                        .github/CODEOWNERS
+┌──────────────────────┐             ┌──────────────────────────┐
+│ domains:             │             │ # 자동 생성               │
+│   frontend:          │  ────────►  │ /src/components/** @carol │
+│     primary: carol   │  CODEOWNERS │ /**/*.svelte @carol @dave │
+│     backup: dave     │  생성       │                           │
+│     paths:           │             │ /src/api/** @alice @bob   │
+│       - src/comp/**  │             └──────────────────────────┘
+│       - **/*.svelte  │
+│   backend:           │             TODO.md (자동 할당)
+│     primary: alice   │             ┌──────────────────────────┐
+│     backup: bob      │  ────────►  │ [P0] Fix auth — @alice   │
+│     paths:           │  autoAssign │   (backend 도메인)       │
+│       - src/api/**   │             │ [P1] Update UI — @carol  │
+└──────────────────────┘             │   (frontend 도메인)      │
+                                     └──────────────────────────┘
+```
+
+### 파일 → 도메인 → 스튜어드 매핑
+
+파일이 변경되면, 스튜어드가 체인을 추적합니다:
+
+```
+src/components/Button.tsx → frontend 도메인 → carol (주담당), dave (백업)
+dags/daily_etl.py        → data-engineering → dave (주담당)
+Dockerfile               → infrastructure   → eve (주담당)
+src/api/auth.ts          → backend 도메인   → alice (주담당), bob (백업)
+```
+
+### 8개 기본 도메인
+
+| 도메인 | 범위 | 예시 패턴 |
+|--------|------|----------|
+| `languages` | 언어별 코드 | `**/*.ts`, `**/*.py`, `**/*.go` |
+| `frontend` | UI 컴포넌트 & 프레임워크 | `src/components/**`, `**/*.svelte` |
+| `backend` | 서버 & API 코드 | `src/api/**`, `routes/**` |
+| `data-engineering` | 파이프라인 & DAG | `dags/**`, `pipelines/**` |
+| `infrastructure` | 배포 & CI/CD | `Dockerfile`, `terraform/**` |
+| `database` | 스키마 & 마이그레이션 | `**/*.sql`, `migrations/**` |
+| `quality` | 테스트 & 스펙 | `**/*.test.ts`, `__tests__/**` |
+| `documentation` | 문서 & 가이드 | `docs/**`, `**/*.md` |
 
 ## 빠른 시작
 
@@ -76,6 +138,16 @@ bunx omcustom-team todo list
 # 새 팀 작업 추가
 bunx omcustom-team todo add API 요청 제한 수정
 ```
+
+### `omcustom-team recommend`
+
+프로젝트를 스캔하고 에이전트를 추천합니다:
+
+```bash
+bunx omcustom-team recommend
+```
+
+파일 확장자, 설정 파일, 디렉토리 패턴, 매니페스트 의존성을 분석하여 기술 스택에 가장 적합한 oh-my-customcode 에이전트를 추천합니다.
 
 ## 대시보드
 
@@ -227,9 +299,9 @@ bun run build        # 프로덕션 빌드
 | 단계 | 기능 | 상태 |
 |------|------|------|
 | V1 | Guardian CI, 세션 로깅, 스튜어드, 팀 TODO | **출시 (v0.2.0)** |
-| V1.5 | 정적 HTML 리포트 (`omcustom-team report`) | 계획됨 |
-| V2 | 대시보드 고도화 — 온톨로지 그래프, 세션 타임라인, RAR 메트릭 | 계획됨 |
-| V3 | 적응형 확장 -- 자동 감지 및 추천 | 계획됨 |
+| V1.5 | 정적 HTML 리포트 (`omcustom-team report`) | **출시 (v0.5.0)** |
+| V2 | 대시보드 고도화 — 온톨로지 그래프, 세션 타임라인, RAR 메트릭 | **출시 (v0.5.0)** |
+| V3 | 적응형 확장 -- 자동 감지 및 추천 | **출시 (v0.5.0)** |
 
 ## 관련 프로젝트
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oh-my-customcode/oh-my-teammates",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Team collaboration addon for oh-my-customcode - organizational harness management",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Enhanced Steward system documentation with diagrams, examples, and deep dive analysis
- Added missing Recommender and ReportGenerator module documentation
- Bumped version to 0.5.1

## Changes
- **README.md / README_ko.md**: Added "How Stewards Work" section, Recommender/Report modules, recommend CLI docs, roadmap update
- **ARCHITECTURE.md / ARCHITECTURE_ko.md**: Added Steward Deep Dive, Recommender/Report sections, expanded architecture diagram, version bump
- **package.json**: 0.5.0 → 0.5.1
- **CLAUDE.md**: 0.4.5 → 0.5.1

## Test plan
- [ ] Verify all markdown renders correctly on GitHub
- [ ] Verify ASCII diagrams display properly
- [ ] Verify EN/KO documents have matching structure
- [ ] Verify version references are consistent (0.5.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)