### PR TITLE
feat: implement v0.6.0 features (#100, #101, #103, #104, #107)

### DIFF
--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -59,7 +59,9 @@ describe('runCli', () => {
       const { runCli } = await import('../cli');
       await expect(runCli(['unknown-command'])).rejects.toThrow('process.exit(1)');
       expect(
-        consoleLogs.some((l) => l.includes('Usage: omcustom-team [init|todo|report|recommend]')),
+        consoleLogs.some((l) =>
+          l.includes('Usage: omcustom-team [init|todo|report|recommend|sessions]'),
+        ),
       ).toBe(true);
       expect(processExitCode).toBe(1);
     });
@@ -68,7 +70,9 @@ describe('runCli', () => {
       const { runCli } = await import('../cli');
       await expect(runCli([])).rejects.toThrow('process.exit(1)');
       expect(
-        consoleLogs.some((l) => l.includes('Usage: omcustom-team [init|todo|report|recommend]')),
+        consoleLogs.some((l) =>
+          l.includes('Usage: omcustom-team [init|todo|report|recommend|sessions]'),
+        ),
       ).toBe(true);
       expect(processExitCode).toBe(1);
     });
@@ -704,6 +708,229 @@ describe('runCli', () => {
       );
 
       recommendSpy.mockRestore();
+    });
+  });
+
+  // ── sessions command ──────────────────────────────────────────────────────
+
+  describe('sessions command', () => {
+    let originalCwd: string;
+
+    beforeEach(() => {
+      originalCwd = process.cwd();
+    });
+
+    afterEach(() => {
+      process.chdir(originalCwd);
+    });
+
+    it('prints message and exits when no sessions database exists', async () => {
+      // Change to a temp dir that has no sessions.db
+      const emptyDir = makeTempDir();
+      process.chdir(emptyDir);
+
+      const { runCli } = await import('../cli');
+      await expect(runCli(['sessions'])).rejects.toThrow('process.exit(1)');
+
+      expect(consoleLogs.some((l) => l.includes('No sessions database found'))).toBe(true);
+      expect(processExitCode).toBe(1);
+
+      cleanup(emptyDir);
+    });
+
+    it('prints "No sessions found." when database exists but is empty', async () => {
+      const tmpDir = makeTempDir();
+      const teamDir = join(tmpDir, '.claude', 'team');
+      mkdirSync(teamDir, { recursive: true });
+      process.chdir(tmpDir);
+
+      const sessionLoggerModule = await import('../session-logger');
+      const listSpy = spyOn(
+        sessionLoggerModule.SessionLogger.prototype,
+        'listSessions',
+      ).mockReturnValue([]);
+      const closeSpy = spyOn(
+        sessionLoggerModule.SessionLogger.prototype,
+        'close',
+      ).mockImplementation(() => {});
+
+      // Create the DB file so existsSync returns true
+      writeFileSync(join(teamDir, 'sessions.db'), '');
+
+      const { runCli } = await import('../cli');
+      await runCli(['sessions']);
+
+      expect(consoleLogs.some((l) => l.includes('No sessions found.'))).toBe(true);
+
+      listSpy.mockRestore();
+      closeSpy.mockRestore();
+      cleanup(tmpDir);
+    });
+
+    it('lists sessions with correct format when sessions exist', async () => {
+      const tmpDir = makeTempDir();
+      const teamDir = join(tmpDir, '.claude', 'team');
+      mkdirSync(teamDir, { recursive: true });
+      writeFileSync(join(teamDir, 'sessions.db'), '');
+      process.chdir(tmpDir);
+
+      const sessionLoggerModule = await import('../session-logger');
+      const mockSessions = [
+        {
+          id: 'sess-1',
+          startedAt: '2024-03-10T09:30:00.000Z',
+          endedAt: '2024-03-10T10:00:00.000Z',
+          user: 'alice',
+          branch: 'feature/auth',
+          summary: 'Implemented OAuth flow',
+        },
+        {
+          id: 'sess-2',
+          startedAt: '2024-03-10T11:00:00.000Z',
+          endedAt: null,
+          user: 'bob',
+          branch: 'develop',
+          summary: null,
+        },
+      ];
+      const listSpy = spyOn(
+        sessionLoggerModule.SessionLogger.prototype,
+        'listSessions',
+      ).mockReturnValue(mockSessions);
+      const closeSpy = spyOn(
+        sessionLoggerModule.SessionLogger.prototype,
+        'close',
+      ).mockImplementation(() => {});
+
+      const { runCli } = await import('../cli');
+      await runCli(['sessions']);
+
+      // Completed session uses ✓
+      expect(
+        consoleLogs.some(
+          (l) => l.includes('✓') && l.includes('@alice') && l.includes('feature/auth'),
+        ),
+      ).toBe(true);
+      // Active session uses →
+      expect(
+        consoleLogs.some((l) => l.includes('→') && l.includes('@bob') && l.includes('develop')),
+      ).toBe(true);
+      // No summary shown as (no summary)
+      expect(consoleLogs.some((l) => l.includes('(no summary)'))).toBe(true);
+      // Summary shown for alice's session
+      expect(consoleLogs.some((l) => l.includes('Implemented OAuth flow'))).toBe(true);
+
+      listSpy.mockRestore();
+      closeSpy.mockRestore();
+      cleanup(tmpDir);
+    });
+
+    it('passes search option when --search flag is provided', async () => {
+      const tmpDir = makeTempDir();
+      const teamDir = join(tmpDir, '.claude', 'team');
+      mkdirSync(teamDir, { recursive: true });
+      writeFileSync(join(teamDir, 'sessions.db'), '');
+      process.chdir(tmpDir);
+
+      const sessionLoggerModule = await import('../session-logger');
+      const listSpy = spyOn(
+        sessionLoggerModule.SessionLogger.prototype,
+        'listSessions',
+      ).mockReturnValue([]);
+      const closeSpy = spyOn(
+        sessionLoggerModule.SessionLogger.prototype,
+        'close',
+      ).mockImplementation(() => {});
+
+      const { runCli } = await import('../cli');
+      await runCli(['sessions', '--search', 'oauth']);
+
+      expect(listSpy).toHaveBeenCalledWith(expect.objectContaining({ search: 'oauth' }));
+
+      listSpy.mockRestore();
+      closeSpy.mockRestore();
+      cleanup(tmpDir);
+    });
+
+    it('passes user option when --user flag is provided', async () => {
+      const tmpDir = makeTempDir();
+      const teamDir = join(tmpDir, '.claude', 'team');
+      mkdirSync(teamDir, { recursive: true });
+      writeFileSync(join(teamDir, 'sessions.db'), '');
+      process.chdir(tmpDir);
+
+      const sessionLoggerModule = await import('../session-logger');
+      const listSpy = spyOn(
+        sessionLoggerModule.SessionLogger.prototype,
+        'listSessions',
+      ).mockReturnValue([]);
+      const closeSpy = spyOn(
+        sessionLoggerModule.SessionLogger.prototype,
+        'close',
+      ).mockImplementation(() => {});
+
+      const { runCli } = await import('../cli');
+      await runCli(['sessions', '--user', 'alice']);
+
+      expect(listSpy).toHaveBeenCalledWith(expect.objectContaining({ user: 'alice' }));
+
+      listSpy.mockRestore();
+      closeSpy.mockRestore();
+      cleanup(tmpDir);
+    });
+
+    it('passes limit option when --limit flag is provided', async () => {
+      const tmpDir = makeTempDir();
+      const teamDir = join(tmpDir, '.claude', 'team');
+      mkdirSync(teamDir, { recursive: true });
+      writeFileSync(join(teamDir, 'sessions.db'), '');
+      process.chdir(tmpDir);
+
+      const sessionLoggerModule = await import('../session-logger');
+      const listSpy = spyOn(
+        sessionLoggerModule.SessionLogger.prototype,
+        'listSessions',
+      ).mockReturnValue([]);
+      const closeSpy = spyOn(
+        sessionLoggerModule.SessionLogger.prototype,
+        'close',
+      ).mockImplementation(() => {});
+
+      const { runCli } = await import('../cli');
+      await runCli(['sessions', '--limit', '5']);
+
+      expect(listSpy).toHaveBeenCalledWith(expect.objectContaining({ limit: 5 }));
+
+      listSpy.mockRestore();
+      closeSpy.mockRestore();
+      cleanup(tmpDir);
+    });
+
+    it('uses -s shorthand for search', async () => {
+      const tmpDir = makeTempDir();
+      const teamDir = join(tmpDir, '.claude', 'team');
+      mkdirSync(teamDir, { recursive: true });
+      writeFileSync(join(teamDir, 'sessions.db'), '');
+      process.chdir(tmpDir);
+
+      const sessionLoggerModule = await import('../session-logger');
+      const listSpy = spyOn(
+        sessionLoggerModule.SessionLogger.prototype,
+        'listSessions',
+      ).mockReturnValue([]);
+      const closeSpy = spyOn(
+        sessionLoggerModule.SessionLogger.prototype,
+        'close',
+      ).mockImplementation(() => {});
+
+      const { runCli } = await import('../cli');
+      await runCli(['sessions', '-s', 'fix']);
+
+      expect(listSpy).toHaveBeenCalledWith(expect.objectContaining({ search: 'fix' }));
+
+      listSpy.mockRestore();
+      closeSpy.mockRestore();
+      cleanup(tmpDir);
     });
   });
 

--- a/src/__tests__/recommender.test.ts
+++ b/src/__tests__/recommender.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Recommender } from '../recommender';
+import { SessionLogger } from '../session-logger';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -280,6 +281,108 @@ describe('Recommender', () => {
         expect(Array.isArray(rec.reasons)).toBe(true);
         expect(rec.confidence).toBeGreaterThanOrEqual(0);
         expect(rec.confidence).toBeLessThanOrEqual(1);
+      }
+    });
+  });
+
+  // ── Layer 5: frequency boost ──────────────────────────────────────────────
+
+  describe('Layer 5: frequency boost', () => {
+    it('should boost confidence for agents with spawn history', () => {
+      const dbPath = join(tmpDir, 'sessions.db');
+      const logger = new SessionLogger(dbPath);
+      logger.startSession('alice', 'main');
+      logger.logEvent('agent_spawn', { agent: 'lang-typescript-expert' });
+      logger.logEvent('agent_spawn', { agent: 'lang-typescript-expert' });
+      logger.endSession();
+      logger.close();
+
+      const projectDir = join(tmpDir, 'project');
+      mkdirSync(projectDir);
+      for (let i = 0; i < 5; i++) {
+        writeFileSync(join(projectDir, `file${i}.ts`), '// test');
+      }
+
+      const recommender = new Recommender(projectDir);
+
+      const withoutBoost = recommender.recommend({ minConfidence: 0.01 });
+      const tsEntryWithout = withoutBoost.find((r) => r.agent === 'lang-typescript-expert');
+
+      // Use a fresh Recommender to avoid cache
+      const recommenderWithBoost = new Recommender(projectDir);
+      const withBoost = recommenderWithBoost.recommend({
+        minConfidence: 0.01,
+        sessionsDbPath: dbPath,
+      });
+      const tsEntryWith = withBoost.find((r) => r.agent === 'lang-typescript-expert');
+
+      expect(tsEntryWith).toBeDefined();
+      expect(tsEntryWithout).toBeDefined();
+      if (tsEntryWith !== undefined && tsEntryWithout !== undefined) {
+        expect(tsEntryWith.confidence).toBeGreaterThan(tsEntryWithout.confidence);
+        expect(tsEntryWith.reasons).toContain('used 2 time(s) in past sessions');
+      }
+    });
+
+    it('should cap confidence at 1.0', () => {
+      const dbPath = join(tmpDir, 'sessions-cap.db');
+      const logger = new SessionLogger(dbPath);
+      logger.startSession('alice', 'main');
+      logger.logEvent('agent_spawn', { agent: 'lang-typescript-expert' });
+      logger.endSession();
+      logger.close();
+
+      const projectDir = join(tmpDir, 'project-cap');
+      mkdirSync(projectDir);
+      for (let i = 0; i < 10; i++) {
+        writeFileSync(join(projectDir, `file${i}.ts`), '// test');
+      }
+      writeFileSync(join(projectDir, 'tsconfig.json'), '{}');
+
+      const recommender = new Recommender(projectDir);
+      const results = recommender.recommend({ minConfidence: 0.01, sessionsDbPath: dbPath });
+      const tsEntry = results.find((r) => r.agent === 'lang-typescript-expert');
+
+      expect(tsEntry).toBeDefined();
+      if (tsEntry !== undefined) {
+        expect(tsEntry.confidence).toBeLessThanOrEqual(1.0);
+      }
+    });
+
+    it('should skip gracefully when DB is missing', () => {
+      const projectDir = join(tmpDir, 'project-missing');
+      mkdirSync(projectDir);
+      writeFileSync(join(projectDir, 'file.ts'), '// test');
+
+      const recommender = new Recommender(projectDir);
+      const results = recommender.recommend({ sessionsDbPath: '/nonexistent/path/sessions.db' });
+      expect(Array.isArray(results)).toBe(true);
+    });
+
+    it('should not boost agents without spawn history', () => {
+      const dbPath = join(tmpDir, 'sessions-noagent.db');
+      const logger = new SessionLogger(dbPath);
+      logger.startSession('alice', 'main');
+      logger.logEvent('agent_spawn', { agent: 'some-other-agent' });
+      logger.endSession();
+      logger.close();
+
+      const projectDir = join(tmpDir, 'project-noboost');
+      mkdirSync(projectDir);
+      for (let i = 0; i < 5; i++) {
+        writeFileSync(join(projectDir, `file${i}.ts`), '// test');
+      }
+
+      const withoutBoostRec = new Recommender(projectDir);
+      const withoutBoost = withoutBoostRec.recommend({ minConfidence: 0.01 });
+      const tsWithout = withoutBoost.find((r) => r.agent === 'lang-typescript-expert');
+
+      const withBoostRec = new Recommender(projectDir);
+      const withBoost = withBoostRec.recommend({ minConfidence: 0.01, sessionsDbPath: dbPath });
+      const tsWithBoost = withBoost.find((r) => r.agent === 'lang-typescript-expert');
+
+      if (tsWithBoost !== undefined && tsWithout !== undefined) {
+        expect(tsWithBoost.confidence).toBe(tsWithout.confidence);
       }
     });
   });

--- a/src/__tests__/report.test.ts
+++ b/src/__tests__/report.test.ts
@@ -305,6 +305,88 @@ describe('ReportGenerator', () => {
   });
 });
 
+// ── domain exclusion (Issue #104) ─────────────────────────────────────────────
+
+describe('domain exclusion', () => {
+  let tmpDir: string;
+  let teamDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+    teamDir = createTeamDir(tmpDir);
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  function writeMultiDomainStewards(dir: string): void {
+    const stewardsYaml = stringify({
+      stewards: {
+        version: '1.0',
+        domains: {
+          frontend: { primary: 'bob', backup: null, paths: ['src/components/**'] },
+          backend: { primary: 'alice', backup: 'bob', paths: ['src/api/**'] },
+        },
+      },
+    });
+    writeFileSync(join(dir, 'STEWARDS.yaml'), stewardsYaml, 'utf-8');
+  }
+
+  it('should exclude specified domains from report', async () => {
+    writeMultiDomainStewards(teamDir);
+
+    const generator = new ReportGenerator(tmpDir);
+    const outputPath = await generator.generate({ excludeDomains: ['frontend'] });
+
+    const html = readFileSync(outputPath, 'utf-8');
+    // 'backend' domain IS present in the Domain Ownership Matrix
+    expect(html).toContain('backend');
+    // 'frontend' domain should NOT appear in the domains table section
+    // Note: it may still appear in member domain lists; check domain matrix rows
+    const domainMatrixMatch = html.match(/Domain Ownership Matrix[\s\S]*?Coverage Gaps/);
+    expect(domainMatrixMatch).not.toBeNull();
+    // biome-ignore lint/style/noNonNullAssertion: existence verified by not.toBeNull above
+    expect(domainMatrixMatch![0]).not.toContain('>frontend<');
+    // biome-ignore lint/style/noNonNullAssertion: existence verified by not.toBeNull above
+    expect(domainMatrixMatch![0]).toContain('>backend<');
+  });
+
+  it('should exclude domains from coverage gaps', async () => {
+    // frontend has no backup — would normally be a coverage gap
+    writeMultiDomainStewards(teamDir);
+
+    const generator = new ReportGenerator(tmpDir);
+    const outputPath = await generator.generate({ excludeDomains: ['frontend'] });
+
+    const html = readFileSync(outputPath, 'utf-8');
+    // After exclusion, only backend remains and it has a backup — so all covered
+    expect(html).toContain('All domains have backup stewards.');
+  });
+
+  it('should include all domains when excludeDomains is empty', async () => {
+    writeMultiDomainStewards(teamDir);
+
+    const generator = new ReportGenerator(tmpDir);
+    const outputPath = await generator.generate({ excludeDomains: [] });
+
+    const html = readFileSync(outputPath, 'utf-8');
+    expect(html).toContain('frontend');
+    expect(html).toContain('backend');
+  });
+
+  it('should include all domains when excludeDomains is undefined', async () => {
+    writeMultiDomainStewards(teamDir);
+
+    const generator = new ReportGenerator(tmpDir);
+    const outputPath = await generator.generate();
+
+    const html = readFileSync(outputPath, 'utf-8');
+    expect(html).toContain('frontend');
+    expect(html).toContain('backend');
+  });
+});
+
 // ── generateReportHtml ────────────────────────────────────────────────────────
 
 describe('generateReportHtml', () => {

--- a/src/__tests__/session-logger.test.ts
+++ b/src/__tests__/session-logger.test.ts
@@ -353,3 +353,174 @@ describe('SessionLogger', () => {
     });
   });
 });
+
+// ── listSessions with search (Issue #101) ─────────────────────────────────────
+
+describe('listSessions with search', () => {
+  it('should find sessions by summary keyword', () => {
+    const searchLogger = new SessionLogger(join(makeTempDir(), 'search-test.db'));
+
+    searchLogger.startSession('alice', 'main');
+    searchLogger.endSession('Fixed authentication bug');
+
+    searchLogger.startSession('bob', 'feature/login');
+    searchLogger.endSession('Added new login page');
+
+    searchLogger.startSession('charlie', 'develop');
+    searchLogger.endSession('Refactored database layer');
+
+    const results = searchLogger.listSessions({ search: 'login' });
+    // "Added new login page" matches summary, "feature/login" matches branch — same row (bob)
+    expect(results.length).toBe(1);
+    expect(results[0]?.user).toBe('bob');
+
+    searchLogger.close();
+  });
+
+  it('should find sessions by branch name', () => {
+    const searchLogger = new SessionLogger(join(makeTempDir(), 'search-branch.db'));
+
+    searchLogger.startSession('alice', 'feature/auth');
+    searchLogger.endSession('Work on auth');
+
+    searchLogger.startSession('bob', 'main');
+    searchLogger.endSession('Hotfix');
+
+    const results = searchLogger.listSessions({ search: 'auth' });
+    // branch "feature/auth" and summary "Work on auth" both match — but it's the same row (alice)
+    expect(results.length).toBe(1);
+    expect(results[0]?.user).toBe('alice');
+
+    searchLogger.close();
+  });
+
+  it('should find sessions by user name', () => {
+    const searchLogger = new SessionLogger(join(makeTempDir(), 'search-user.db'));
+
+    searchLogger.startSession('alice', 'main');
+    searchLogger.endSession('Task 1');
+
+    searchLogger.startSession('bob', 'main');
+    searchLogger.endSession('Task 2');
+
+    const results = searchLogger.listSessions({ search: 'alice' });
+    expect(results.length).toBe(1);
+    expect(results[0]?.user).toBe('alice');
+
+    searchLogger.close();
+  });
+
+  it('should return empty for no matches', () => {
+    const searchLogger = new SessionLogger(join(makeTempDir(), 'search-empty.db'));
+
+    searchLogger.startSession('alice', 'main');
+    searchLogger.endSession('Some task');
+
+    const results = searchLogger.listSessions({ search: 'nonexistent' });
+    expect(results.length).toBe(0);
+
+    searchLogger.close();
+  });
+
+  it('should handle NULL summary gracefully', () => {
+    const searchLogger = new SessionLogger(join(makeTempDir(), 'search-null.db'));
+
+    searchLogger.startSession('alice', 'main');
+    // Don't end session — summary stays NULL
+
+    searchLogger.startSession('bob', 'main');
+    searchLogger.endSession('Completed task');
+
+    const results = searchLogger.listSessions({ search: 'alice' });
+    // Should find alice by user field, even though summary is NULL
+    expect(results.length).toBe(1);
+    expect(results[0]?.user).toBe('alice');
+
+    searchLogger.close();
+  });
+
+  it('should combine search with user filter', () => {
+    const searchLogger = new SessionLogger(join(makeTempDir(), 'search-combo.db'));
+
+    searchLogger.startSession('alice', 'feature/login');
+    searchLogger.endSession('Login work');
+
+    searchLogger.startSession('bob', 'feature/login');
+    searchLogger.endSession('Login review');
+
+    const results = searchLogger.listSessions({ search: 'login', user: 'alice' });
+    expect(results.length).toBe(1);
+    expect(results[0]?.user).toBe('alice');
+
+    searchLogger.close();
+  });
+});
+
+// ── parameterized days filter (Issue #100) ────────────────────────────────────
+
+describe('parameterized days filter', () => {
+  it('should filter session stats by days parameter', () => {
+    const statsLogger = new SessionLogger(join(makeTempDir(), 'param-stats.db'));
+
+    statsLogger.startSession('alice', 'main');
+    statsLogger.endSession('Recent task');
+
+    const stats = statsLogger.getSessionStats(30);
+    expect(stats.totalSessions).toBeGreaterThanOrEqual(1);
+
+    const statsAll = statsLogger.getSessionStats();
+    expect(statsAll.totalSessions).toBeGreaterThanOrEqual(1);
+
+    statsLogger.close();
+  });
+
+  it('should filter event stats by days parameter', () => {
+    const eventsLogger = new SessionLogger(join(makeTempDir(), 'param-events.db'));
+
+    eventsLogger.startSession('alice', 'main');
+    eventsLogger.logEvent('note', { message: 'test' });
+    eventsLogger.endSession();
+
+    const events = eventsLogger.getEventStats(30);
+    expect(events.length).toBeGreaterThanOrEqual(1);
+
+    const eventsAll = eventsLogger.getEventStats();
+    expect(eventsAll.length).toBeGreaterThanOrEqual(1);
+
+    eventsLogger.close();
+  });
+
+  it('should filter active users by days parameter', () => {
+    const usersLogger = new SessionLogger(join(makeTempDir(), 'param-users.db'));
+
+    usersLogger.startSession('alice', 'main');
+    usersLogger.endSession();
+
+    const users = usersLogger.getActiveUsers(30);
+    expect(users.length).toBe(1);
+    expect(users[0]?.user).toBe('alice');
+
+    const usersAll = usersLogger.getActiveUsers();
+    expect(usersAll.length).toBe(1);
+
+    usersLogger.close();
+  });
+
+  it('should filter branch distribution by days parameter', () => {
+    const branchLogger = new SessionLogger(join(makeTempDir(), 'param-branches.db'));
+
+    branchLogger.startSession('alice', 'main');
+    branchLogger.endSession();
+
+    branchLogger.startSession('bob', 'develop');
+    branchLogger.endSession();
+
+    const branches = branchLogger.getBranchDistribution(30);
+    expect(branches.length).toBe(2);
+
+    const branchesAll = branchLogger.getBranchDistribution();
+    expect(branchesAll.length).toBe(2);
+
+    branchLogger.close();
+  });
+});

--- a/src/__tests__/team-todo.test.ts
+++ b/src/__tests__/team-todo.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
-import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { stringify } from 'yaml';
 import { TeamTodo } from '../team-todo';
@@ -330,7 +330,103 @@ describe('exists()', () => {
   });
 });
 
-// 8. createTemplate()
+// 8. labels support
+describe('labels support', () => {
+  it('should parse labels from TODO line', () => {
+    const content = `# Team TODO\n\n## team: [P1] Fix login bug [bug, urgent]\n`;
+    const path = writeTodo(tmpDir, content);
+    const todo = new TeamTodo(path);
+
+    const items = todo.load();
+    expect(items.length).toBe(1);
+    expect(items[0]?.labels).toEqual(['bug', 'urgent']);
+  });
+
+  it('should handle items without labels', () => {
+    const content = `# Team TODO\n\n## team: [P1] Fix login bug\n`;
+    const path = writeTodo(tmpDir, content);
+    const todo = new TeamTodo(path);
+
+    const items = todo.load();
+    expect(items.length).toBe(1);
+    expect(items[0]?.labels).toBeUndefined();
+  });
+
+  it('should serialize labels correctly', () => {
+    const content = `# Team TODO\n\n## team: [P1] Fix login bug [bug, urgent]\n`;
+    const path = writeTodo(tmpDir, content);
+    const todo = new TeamTodo(path);
+
+    todo.load();
+    todo.save();
+
+    const saved = readFileSync(path, 'utf-8');
+    expect(saved).toContain('[bug, urgent]');
+  });
+
+  it('should roundtrip labels through parse/serialize', () => {
+    const content = `# Team TODO\n\n## team: [P1] Fix login bug [bug, urgent]\n`;
+    const path = writeTodo(tmpDir, content);
+    const todo = new TeamTodo(path);
+
+    const items1 = todo.load();
+    todo.save();
+
+    const todo2 = new TeamTodo(path);
+    const items2 = todo2.load();
+
+    expect(items2[0]?.labels).toEqual(items1[0]?.labels);
+    expect(items2[0]?.description).toEqual(items1[0]?.description);
+  });
+
+  it('should filter by label', () => {
+    const content = [
+      '# Team TODO',
+      '',
+      '## team: [P1] Fix login bug [bug, urgent]',
+      '## team: [P1] Add feature [feature]',
+      '## team: [P2] Update docs',
+      '',
+    ].join('\n');
+    const path = writeTodo(tmpDir, content);
+    const todo = new TeamTodo(path);
+    todo.load();
+
+    const bugItems = todo.list({ label: 'bug' });
+    expect(bugItems.length).toBe(1);
+    expect(bugItems[0]?.description).toBe('Fix login bug');
+
+    const featureItems = todo.list({ label: 'feature' });
+    expect(featureItems.length).toBe(1);
+
+    const noLabelItems = todo.list({ label: 'nonexistent' });
+    expect(noLabelItems.length).toBe(0);
+  });
+
+  it('should handle empty labels brackets', () => {
+    const content = `# Team TODO\n\n## team: [P1] Fix login bug []\n`;
+    const path = writeTodo(tmpDir, content);
+    const todo = new TeamTodo(path);
+
+    const items = todo.load();
+    expect(items.length).toBe(1);
+    expect(items[0]?.labels).toBeUndefined();
+  });
+
+  it('should parse labels with assignee and domain', () => {
+    const content = `# Team TODO\n\n## team: [P1] Fix login bug — @alice (backend) [bug, urgent]\n`;
+    const path = writeTodo(tmpDir, content);
+    const todo = new TeamTodo(path);
+
+    const items = todo.load();
+    expect(items.length).toBe(1);
+    expect(items[0]?.assignee).toBe('alice');
+    expect(items[0]?.domain).toBe('backend');
+    expect(items[0]?.labels).toEqual(['bug', 'urgent']);
+  });
+});
+
+// 9. createTemplate()
 describe('TeamTodo.createTemplate()', () => {
   it('creates a file with template content', () => {
     const path = join(tmpDir, 'TODO.md');

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -100,6 +100,52 @@ export async function runCli(args: string[]): Promise<void> {
       }
       break;
     }
+    case 'sessions': {
+      const { SessionLogger } = await import('./session-logger');
+      const { existsSync } = await import('node:fs');
+      const { resolve } = await import('node:path');
+      const dbPath = resolve('.', '.claude/team/sessions.db');
+
+      if (!existsSync(dbPath)) {
+        console.log('No sessions database found. Run some Claude Code sessions first.');
+        process.exit(1);
+      }
+
+      const logger = new SessionLogger(dbPath);
+
+      try {
+        const searchIdx =
+          args.indexOf('--search') !== -1 ? args.indexOf('--search') : args.indexOf('-s');
+        const search = searchIdx !== -1 ? args[searchIdx + 1] : undefined;
+
+        const userIdx = args.indexOf('--user') !== -1 ? args.indexOf('--user') : args.indexOf('-u');
+        const user = userIdx !== -1 ? args[userIdx + 1] : undefined;
+
+        const limitIdx =
+          args.indexOf('--limit') !== -1 ? args.indexOf('--limit') : args.indexOf('-l');
+        const limit = limitIdx !== -1 ? Number.parseInt(args[limitIdx + 1] ?? '20', 10) : 20;
+
+        const sessions = logger.listSessions({
+          search,
+          user,
+          limit: limit && !Number.isNaN(limit) ? limit : 20,
+        });
+
+        if (sessions.length === 0) {
+          console.log('No sessions found.');
+        } else {
+          for (const s of sessions) {
+            const status = s.endedAt !== null ? '✓' : '→';
+            console.log(
+              `${status} ${s.startedAt.slice(0, 16)} @${s.user} [${s.branch}] ${s.summary ?? '(no summary)'}`,
+            );
+          }
+        }
+      } finally {
+        logger.close();
+      }
+      break;
+    }
     case 'report': {
       const { ReportGenerator } = await import('./report');
       const generator = new ReportGenerator();
@@ -114,10 +160,21 @@ export async function runCli(args: string[]): Promise<void> {
 
       const open = args.includes('--open');
 
+      // Parse --exclude-domain (repeatable)
+      const excludeDomains: string[] = [];
+      for (let i = 1; i < args.length; i++) {
+        const value = args[i + 1];
+        if (args[i] === '--exclude-domain' && value) {
+          excludeDomains.push(value);
+          i++;
+        }
+      }
+
       const outputPath = await generator.generate({
         output,
         days: days && !Number.isNaN(days) ? days : undefined,
         open,
+        excludeDomains: excludeDomains.length > 0 ? excludeDomains : undefined,
       });
       console.log(`Report generated: ${outputPath}`);
       break;
@@ -137,7 +194,13 @@ export async function runCli(args: string[]): Promise<void> {
       const catIdx = args.indexOf('--category');
       const category = catIdx !== -1 ? (args[catIdx + 1] as AgentCategory) : undefined;
 
-      const recommendations = recommender.recommend({ minConfidence, category });
+      const { existsSync } = await import('node:fs');
+      const { resolve } = await import('node:path');
+      const sessionsDbPath = existsSync(resolve('.', '.claude/team/sessions.db'))
+        ? resolve('.', '.claude/team/sessions.db')
+        : undefined;
+
+      const recommendations = recommender.recommend({ minConfidence, category, sessionsDbPath });
 
       if (jsonOutput) {
         console.log(JSON.stringify(recommendations, null, 2));
@@ -163,24 +226,31 @@ export async function runCli(args: string[]): Promise<void> {
       break;
     }
     default: {
-      console.log('Usage: omcustom-team [init|todo|report|recommend]');
+      console.log('Usage: omcustom-team [init|todo|report|recommend|sessions]');
       console.log('');
       console.log('Commands:');
       console.log('  init [--yes|-y]    Initialize team configuration');
       console.log('  todo [list|add]    Manage team tasks');
       console.log('  report [options]       Generate team report');
       console.log('  recommend [options]    Recommend agents for this project');
+      console.log('  sessions [options]     Search and list sessions');
       console.log('');
       console.log('Report options:');
       console.log('    --output, -o <path>  Output file path');
       console.log('    --days, -d <n>       Filter to last N days');
       console.log('    --open               Open report in browser');
+      console.log('    --exclude-domain <n> Exclude domain from report (repeatable)');
       console.log('');
       console.log('Recommend options:');
       console.log('    --json               Output as JSON');
       console.log('    --verbose            Show detection reasons');
       console.log('    --min-confidence <n> Minimum confidence (default: 0.3)');
       console.log('    --category <name>    Filter by category');
+      console.log('');
+      console.log('Session options:');
+      console.log('    --search, -s <term>  Search in summary/branch/user');
+      console.log('    --user, -u <name>    Filter by user');
+      console.log('    --limit, -l <n>      Max results (default: 20)');
       process.exit(1);
     }
   }

--- a/src/recommender.ts
+++ b/src/recommender.ts
@@ -1,3 +1,4 @@
+import { Database } from 'bun:sqlite';
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { basename, extname, join, resolve } from 'node:path';
 import type { AgentCatalogEntry, AgentCategory } from './agent-catalog';
@@ -21,6 +22,7 @@ export interface AgentRecommendation {
 export interface RecommendOptions {
   minConfidence?: number;
   category?: AgentCategory;
+  sessionsDbPath?: string;
 }
 
 interface ScanResult {
@@ -54,13 +56,14 @@ const MANIFEST_FILES = [
 
 export class Recommender {
   private basePath: string;
+  private spawnFrequencyCache: Map<string, number> | null = null;
 
   constructor(basePath = '.') {
     this.basePath = basePath;
   }
 
   recommend(options: RecommendOptions = {}): AgentRecommendation[] {
-    const { minConfidence = 0.3, category } = options;
+    const { minConfidence = 0.3, category, sessionsDbPath } = options;
 
     const scan = this.scanFiles();
     const manifests = this.parseManifests();
@@ -68,7 +71,7 @@ export class Recommender {
     const results: AgentRecommendation[] = [];
 
     for (const entry of AGENT_CATALOG) {
-      const { confidence, reasons } = this.scoreAgent(entry, scan, manifests);
+      const { confidence, reasons } = this.scoreAgent(entry, scan, manifests, sessionsDbPath);
 
       if (confidence < minConfidence) {
         continue;
@@ -177,12 +180,49 @@ export class Recommender {
     return results;
   }
 
+  // ── Private: session frequency ────────────────────────────────────────────
+
+  private readSpawnFrequency(dbPath: string): Map<string, number> {
+    if (this.spawnFrequencyCache !== null) {
+      return this.spawnFrequencyCache;
+    }
+
+    const cache = new Map<string, number>();
+
+    try {
+      const db = new Database(dbPath, { readonly: true });
+
+      try {
+        const rows = db
+          .prepare(
+            `SELECT json_extract(data, '$.agent') AS agent, COUNT(*) AS count
+             FROM session_events
+             WHERE type = 'agent_spawn' AND json_extract(data, '$.agent') IS NOT NULL
+             GROUP BY agent`,
+          )
+          .all() as { agent: string; count: number }[];
+
+        for (const row of rows) {
+          cache.set(row.agent, row.count);
+        }
+      } finally {
+        db.close();
+      }
+    } catch {
+      // DB missing or unreadable — graceful skip
+    }
+
+    this.spawnFrequencyCache = cache;
+    return cache;
+  }
+
   // ── Private: confidence scoring ───────────────────────────────────────────
 
   private scoreAgent(
     entry: AgentCatalogEntry,
     scan: ScanResult,
     manifests: ParsedDependencies[],
+    sessionsDbPath?: string,
   ): { confidence: number; reasons: string[] } {
     let maxConfidence = 0;
     const reasons: string[] = [];
@@ -252,6 +292,17 @@ export class Recommender {
           }
           reasons.push(`${matchedPkgs.join(', ')} in ${rule.manifest}`);
         }
+      }
+    }
+
+    // Layer 5: Historical usage frequency boost
+    if (sessionsDbPath !== undefined) {
+      const frequency = this.readSpawnFrequency(sessionsDbPath);
+      const count = frequency.get(entry.name) ?? 0;
+
+      if (count > 0) {
+        maxConfidence = Math.min(maxConfidence + 0.1, 1.0);
+        reasons.push(`used ${count} time(s) in past sessions`);
       }
     }
 

--- a/src/report.ts
+++ b/src/report.ts
@@ -17,6 +17,7 @@ export interface ReportOptions {
   output?: string;
   days?: number;
   open?: boolean;
+  excludeDomains?: string[];
 }
 
 export class ReportGenerator {
@@ -33,14 +34,15 @@ export class ReportGenerator {
     // 1. Collect data from all sources (graceful fallback)
     const teamConfig = this.collectTeamConfig();
     const domainsMap = this.collectDomains();
+    const filteredDomains = this.applyDomainFilter(domainsMap, options.excludeDomains ?? []);
     const todoItems = this.collectTodos();
     const sessionData = this.collectSessionData(days);
-    const coverageGaps = this.computeCoverageGaps(domainsMap);
+    const coverageGaps = this.computeCoverageGaps(filteredDomains);
 
     // 2. Build ReportData
     const teamName = teamConfig?.name ?? 'Team';
     const members = teamConfig?.members ?? [];
-    const domains = domainsMap ?? {};
+    const domains = filteredDomains ?? {};
 
     const todos = todoItems !== null ? this.summarizeTodos(todoItems) : null;
 
@@ -190,6 +192,23 @@ export class ReportGenerator {
     } finally {
       logger?.close();
     }
+  }
+
+  private applyDomainFilter(
+    domains: ReportData['domains'] | null,
+    exclude: string[],
+  ): ReportData['domains'] | null {
+    if (domains === null || exclude.length === 0) {
+      return domains;
+    }
+    const excludeSet = new Set(exclude);
+    const filtered: ReportData['domains'] = {};
+    for (const [domain, steward] of Object.entries(domains)) {
+      if (!excludeSet.has(domain)) {
+        filtered[domain] = steward;
+      }
+    }
+    return filtered;
   }
 
   private computeCoverageGaps(domains: ReportData['domains'] | null): string[] {

--- a/src/session-logger.ts
+++ b/src/session-logger.ts
@@ -171,13 +171,19 @@ export class SessionLogger {
     };
   }
 
-  listSessions(options?: { user?: string; limit?: number }): Session[] {
+  listSessions(options?: { user?: string; search?: string; limit?: number }): Session[] {
     const conditions: string[] = [];
     const params: (string | number)[] = [];
 
     if (options?.user !== undefined) {
       conditions.push('user = ?');
       params.push(options.user);
+    }
+
+    if (options?.search !== undefined) {
+      const term = `%${options.search}%`;
+      conditions.push('(summary LIKE ? OR branch LIKE ? OR user LIKE ?)');
+      params.push(term, term, term);
     }
 
     const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
@@ -242,8 +248,8 @@ export class SessionLogger {
   }
 
   getSessionStats(days?: number): SessionStats {
-    const whereClause =
-      days !== undefined ? `WHERE started_at >= datetime('now', '-' || ${days} || ' days')` : '';
+    const whereClause = days !== undefined ? `WHERE started_at >= datetime('now', ?)` : '';
+    const params: string[] = days !== undefined ? [`-${days} days`] : [];
 
     const row = this.db
       .prepare<
@@ -253,7 +259,7 @@ export class SessionLogger {
           avg_duration_minutes: number | null;
           total_duration_minutes: number | null;
         },
-        []
+        string[]
       >(
         `SELECT
            COUNT(*) AS total_sessions,
@@ -270,7 +276,7 @@ export class SessionLogger {
            ) AS total_duration_minutes
          FROM sessions ${whereClause}`,
       )
-      .get();
+      .get(...params);
 
     return {
       totalSessions: row?.total_sessions ?? 0,
@@ -281,8 +287,8 @@ export class SessionLogger {
   }
 
   getEventStats(days?: number): EventTypeCount[] {
-    const whereClause =
-      days !== undefined ? `WHERE timestamp >= datetime('now', '-' || ${days} || ' days')` : '';
+    const whereClause = days !== undefined ? `WHERE timestamp >= datetime('now', ?)` : '';
+    const params: string[] = days !== undefined ? [`-${days} days`] : [];
 
     const rows = this.db
       .prepare<
@@ -290,14 +296,14 @@ export class SessionLogger {
           type: string;
           count: number;
         },
-        []
+        string[]
       >(
         `SELECT type, COUNT(*) AS count
          FROM session_events ${whereClause}
          GROUP BY type
          ORDER BY count DESC`,
       )
-      .all();
+      .all(...params);
 
     return rows.map((row) => ({
       type: row.type,
@@ -306,8 +312,8 @@ export class SessionLogger {
   }
 
   getActiveUsers(days?: number): UserActivity[] {
-    const whereClause =
-      days !== undefined ? `WHERE started_at >= datetime('now', '-' || ${days} || ' days')` : '';
+    const whereClause = days !== undefined ? `WHERE started_at >= datetime('now', ?)` : '';
+    const params: string[] = days !== undefined ? [`-${days} days`] : [];
 
     const rows = this.db
       .prepare<
@@ -316,7 +322,7 @@ export class SessionLogger {
           session_count: number;
           total_minutes: number | null;
         },
-        []
+        string[]
       >(
         `SELECT
            user,
@@ -330,7 +336,7 @@ export class SessionLogger {
          GROUP BY user
          ORDER BY session_count DESC`,
       )
-      .all();
+      .all(...params);
 
     return rows.map((row) => ({
       user: row.user,
@@ -340,8 +346,8 @@ export class SessionLogger {
   }
 
   getBranchDistribution(days?: number): BranchCount[] {
-    const whereClause =
-      days !== undefined ? `WHERE started_at >= datetime('now', '-' || ${days} || ' days')` : '';
+    const whereClause = days !== undefined ? `WHERE started_at >= datetime('now', ?)` : '';
+    const params: string[] = days !== undefined ? [`-${days} days`] : [];
 
     const rows = this.db
       .prepare<
@@ -349,14 +355,14 @@ export class SessionLogger {
           branch: string;
           count: number;
         },
-        []
+        string[]
       >(
         `SELECT branch, COUNT(*) AS count
          FROM sessions ${whereClause}
          GROUP BY branch
          ORDER BY count DESC`,
       )
-      .all();
+      .all(...params);
 
     return rows.map((row) => ({
       branch: row.branch,

--- a/src/team-todo.ts
+++ b/src/team-todo.ts
@@ -9,16 +9,19 @@ export interface TodoItem {
   assignee: string | null;
   domain: string | null;
   completed: boolean;
+  labels?: string[];
 }
 
 /**
  * Each TODO line format:
- *   ## {scope}: [{priority}] {description} — @{assignee} ({domain})
+ *   ## {scope}: [{priority}] {description} — @{assignee} ({domain}) [label1, label2]
  * Completed items are prefixed with "~~" and suffixed with "~~":
- *   ## ~~{scope}: [{priority}] {description} — @{assignee} ({domain})~~
+ *   ## ~~{scope}: [{priority}] {description} — @{assignee} ({domain}) [label1, label2]~~
+ *
+ * Labels are an optional trailing bracket group after the assignee/domain section.
  */
 const TODO_LINE_RE =
-  /^##\s+(?:~~)?(\w+):\s+\[(P[012])\]\s+(.+?)(?:\s+—\s+@([\w-]+)(?:\s+\(([^)]+)\))?)?(?:~~)?$/;
+  /^##\s+(?:~~)?(\w+):\s+\[(P[012])\]\s+(.+?)(?:\s+—\s+@([\w-]+)(?:\s+\(([^)]+)\))?)?(?:\s+\[([^\]]*)\])?(?:~~)?$/;
 
 function parseLine(line: string): TodoItem | null {
   const trimmed = line.trim();
@@ -42,13 +45,30 @@ function parseLine(line: string): TodoItem | null {
     return null;
   }
 
+  const description = (match[3] ?? '').trim();
+  const assignee = match[4] ?? null;
+  const domain = match[5] ?? null;
+
+  let labels: string[] | undefined;
+  const labelsStr = match[6];
+  if (labelsStr !== undefined) {
+    const parsed = labelsStr
+      .split(',')
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0);
+    if (parsed.length > 0) {
+      labels = parsed;
+    }
+  }
+
   return {
     scope,
     priority,
-    description: (match[3] ?? '').trim(),
-    assignee: match[4] ?? null,
-    domain: match[5] ?? null,
+    description,
+    assignee,
+    domain,
     completed,
+    ...(labels !== undefined ? { labels } : {}),
   };
 }
 
@@ -59,6 +79,9 @@ function serializeItem(item: TodoItem): string {
     if (item.domain !== null) {
       line += ` (${item.domain})`;
     }
+  }
+  if (item.labels !== undefined && item.labels.length > 0) {
+    line += ` [${item.labels.join(', ')}]`;
   }
   if (item.completed) {
     line = `## ~~${line.slice(3)}~~`;
@@ -128,8 +151,13 @@ export class TeamTodo {
     return true;
   }
 
-  /** Return items, optionally filtered by scope, priority, or assignee. */
-  list(filter?: { scope?: 'team' | 'personal'; priority?: string; assignee?: string }): TodoItem[] {
+  /** Return items, optionally filtered by scope, priority, assignee, or label. */
+  list(filter?: {
+    scope?: 'team' | 'personal';
+    priority?: string;
+    assignee?: string;
+    label?: string;
+  }): TodoItem[] {
     if (!filter) {
       return [...this.items];
     }
@@ -142,6 +170,9 @@ export class TeamTodo {
         return false;
       }
       if (filter.assignee !== undefined && item.assignee !== filter.assignee) {
+        return false;
+      }
+      if (filter.label !== undefined && !(item.labels?.includes(filter.label) ?? false)) {
         return false;
       }
       return true;


### PR DESCRIPTION
## Summary
- **#100** fix: Parameterize SQL time-based queries in SessionLogger (security)
- **#101** feat: Add LIKE-based session search + `sessions` CLI command
- **#103** feat: Add Layer 5 frequency-based agent recommendation boost
- **#104** feat: Add domain exclusion filter to ReportGenerator
- **#107** feat: Add labels support to TodoItem

## Development Order
- Wave 1: #100 (SQL parameterization — security first)
- Wave 2: #101 + #104 (parallel — independent features)
- Wave 3: #103 + #107 (parallel — independent features)

## Changes

### SessionLogger (`src/session-logger.ts`)
- 4 stats methods: string interpolation → `datetime('now', ?)` parameterized queries
- `listSessions()`: added `search?: string` option with LIKE on summary/branch/user

### Recommender (`src/recommender.ts`)
- Layer 5: additive +0.1 confidence boost for agents with `agent_spawn` history
- `readSpawnFrequency()`: readonly `bun:sqlite` access with instance cache
- `RecommendOptions.sessionsDbPath`: optional sessions DB path

### ReportGenerator (`src/report.ts`)
- `ReportOptions.excludeDomains`: filter domains from report output
- `applyDomainFilter()`: excludes domains before HTML generation and coverage gaps

### TeamTodo (`src/team-todo.ts`)
- `TodoItem.labels`: optional string array parsed from trailing `[tag1, tag2]`
- Labels parsing, serialization, round-trip, and filtering support

### CLI (`src/cli.ts`)
- New `sessions` command with `--search/-s`, `--user/-u`, `--limit/-l` flags
- `report --exclude-domain` repeatable flag
- `recommend` auto-detects sessions.db for Layer 5 boost

## Test plan
- [x] 334 tests pass (302 existing + 32 new), 0 failures
- [x] 100% function coverage, 99.86% line coverage
- [x] TypeScript strict mode passes
- [x] Build succeeds (index.js + cli.js)
- [ ] CI pipeline passes

Closes #100, #101, #103, #104, #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)