### PR TITLE
chore: fix version 0.31.1 → 0.7.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,7 +310,7 @@ Team collaboration addon for oh-my-customcode.
 ## Project Info
 
 - **Language**: TypeScript (Bun runtime)
-- **Version**: 0.31.1
+- **Version**: 0.7.0
 - **License**: MIT
 - **Peer Dependency**: oh-my-customcode >= 0.23.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oh-my-customcode/oh-my-teammates",
-  "version": "0.31.1",
+  "version": "0.7.0",
   "description": "Team collaboration addon for oh-my-customcode - organizational harness management",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Fix incorrect version number 0.31.1 → 0.7.0
- Delete v0.31.1 GitHub release and git tag
- Deprecate npm 0.31.1 package

🤖 Generated with [Claude Code](https://claude.com/claude-code)