### PR TITLE
chore: sync upstream oh-my-customcode v0.31.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,12 +176,12 @@ oh-my-customcode로 구동됩니다.
 project/
 +-- CLAUDE.md                    # 진입점
 +-- .claude/
-|   +-- agents/                  # 서브에이전트 정의 (41 파일)
-|   +-- skills/                  # 스킬 (64 디렉토리)
+|   +-- agents/                  # 서브에이전트 정의 (42 파일)
+|   +-- skills/                  # 스킬 (66 디렉토리)
 |   +-- rules/                   # 전역 규칙 (R000-R018)
 |   +-- hooks/                   # 훅 스크립트 (메모리, HUD)
 |   +-- contexts/                # 컨텍스트 파일 (ecomode)
-+-- guides/                      # 레퍼런스 문서 (22 토픽)
++-- guides/                      # 레퍼런스 문서 (24 토픽)
 ```
 
 ## 오케스트레이션
@@ -211,7 +211,7 @@ project/
 |------|------|----------|
 | SW Engineer/Language | 6 | lang-golang-expert, lang-python-expert, lang-rust-expert, lang-kotlin-expert, lang-typescript-expert, lang-java21-expert |
 | SW Engineer/Backend | 5 | be-fastapi-expert, be-springboot-expert, be-go-backend-expert, be-express-expert, be-nestjs-expert |
-| SW Engineer/Frontend | 3 | fe-vercel-agent, fe-vuejs-agent, fe-svelte-agent |
+| SW Engineer/Frontend | 4 | fe-vercel-agent, fe-vuejs-agent, fe-svelte-agent, fe-flutter-agent |
 | SW Engineer/Tooling | 3 | tool-npm-expert, tool-optimizer, tool-bun-expert |
 | DE Engineer | 6 | de-airflow-expert, de-dbt-expert, de-spark-expert, de-kafka-expert, de-snowflake-expert, de-pipeline-expert |
 | SW Engineer/Database | 3 | db-supabase-expert, db-postgres-expert, db-redis-expert |
@@ -220,7 +220,7 @@ project/
 | QA Team | 3 | qa-planner, qa-writer, qa-engineer |
 | Manager | 6 | mgr-creator, mgr-updater, mgr-supplier, mgr-gitnerd, mgr-sauron, mgr-claude-code-bible |
 | System | 2 | sys-memory-keeper, sys-naggy |
-| **총계** | **41** | |
+| **총계** | **42** | |
 
 ## Agent Teams (MUST when enabled)
 

--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
         "bun-types": "^1.3.10",
         "husky": "^9.1.7",
         "lint-staged": "^16.3.2",
-        "oh-my-customcode": "^0.30.6",
+        "oh-my-customcode": "^0.31.1",
       },
       "peerDependencies": {
         "oh-my-customcode": ">=0.23.0",
@@ -89,7 +89,7 @@
 
     "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 
-    "oh-my-customcode": ["oh-my-customcode@0.30.6", "", { "dependencies": { "commander": "^14.0.2", "i18next": "^25.8.0", "yaml": "^2.8.2" }, "bin": { "omcustom": "dist/cli/index.js" } }, "sha512-5D4pfdiTL+xB83GfD59VmbMpCr+VCMrKygA/4Jf3WnwWmyeZEvP5DrrlFh5uGbSnJV1gulf+3Pc2RHoFj8k/3w=="],
+    "oh-my-customcode": ["oh-my-customcode@0.31.1", "", { "dependencies": { "commander": "^14.0.2", "i18next": "^25.8.0", "yaml": "^2.8.2" }, "bin": { "omcustom": "dist/cli/index.js" } }, "sha512-U0oy2JOVlo6q7ltB2MveCz+KCsgNCL2jvl+59pB+gsaPjMt+x57eXY4vv81nMMrcDwe7xD1Z5KNRbjJaq/us+Q=="],
 
     "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "bun-types": "^1.3.10",
     "husky": "^9.1.7",
     "lint-staged": "^16.3.2",
-    "oh-my-customcode": "^0.30.6"
+    "oh-my-customcode": "^0.31.1"
   },
   "dependencies": {
     "yaml": "^2.7.0"


### PR DESCRIPTION
## Summary
- oh-my-customcode devDep `^0.30.6` → `^0.31.1` 범프
- CLAUDE.md 카운트 동기화: 에이전트 41→42, 스킬 64→66, 가이드 22→24
- fe-flutter-agent 에이전트 요약 테이블 추가

## Context
`/research` 스킬로 GitHub 이슈 분석 결과:
- Issue #128은 `propose-upstream.yml`의 정적 grep 패턴이 v0.31.0 기능을 v0.31.1로 잘못 귀속하여 생성된 부정확한 이슈로 닫음
- 분석 과정에서 fe-flutter-agent 팬텀 (카탈로그에만 존재)과 java21-best-practices 스킬 누락 발견
- devDep 범프로 upstream 설치 시 누락 파일들 자동 해결

## Related Issues
- Closes #128
- Created #129 (propose-upstream.yml 개선, P2)
- Created #130 (catalog-agent 일관성 규칙, P3)

## Test plan
- [ ] `bun test` 전체 통과 확인
- [ ] `bun run build` 빌드 성공 확인
- [ ] CI checks 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)