### PR TITLE
fix: narrow propose-upstream commit scan to push event range

### DIFF
--- a/.github/workflows/propose-upstream.yml
+++ b/.github/workflows/propose-upstream.yml
@@ -27,21 +27,23 @@ jobs:
 
       - name: Get changed files since last run
         id: changes
+        env:
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.event.after }}
         run: |
-          # Get the merge commit and its parents
-          MERGE_BASE=$(git log --merges -1 --format=%H 2>/dev/null || echo "")
-          if [ -z "$MERGE_BASE" ]; then
-            echo "No merge commits found, using last 2 commits"
-            DIFF_BASE="HEAD~1"
+          # Use push event range to scan only the triggering commits (not cumulative history)
+          # Fall back to HEAD~1..HEAD for first push (before is all zeros)
+          if [ -z "$BEFORE" ] || echo "$BEFORE" | grep -q "^0\{40\}$"; then
+            RANGE="HEAD~1..HEAD"
           else
-            DIFF_BASE="${MERGE_BASE}^1"
+            RANGE="${BEFORE}..${AFTER}"
           fi
 
-          CHANGED=$(git diff --name-only "$DIFF_BASE" HEAD -- src/ | tr '\n' ' ')
+          CHANGED=$(git diff --name-only "$RANGE" -- src/ | tr '\n' ' ')
           echo "files=$CHANGED" >> $GITHUB_OUTPUT
 
-          # Extract commit messages for analysis
-          MESSAGES=$(git log "$DIFF_BASE"..HEAD --format="%s" | tr '\n' '|')
+          # Extract commit messages for analysis (push event range only)
+          MESSAGES=$(git log "$RANGE" --format="%s" | tr '\n' '|')
           echo "messages=$MESSAGES" >> $GITHUB_OUTPUT
 
       - name: Detect proposable patterns

--- a/src/agent-catalog.ts
+++ b/src/agent-catalog.ts
@@ -95,7 +95,7 @@ export const AGENT_CATALOG: AgentCatalogEntry[] = [
     },
   },
 
-  // ── Backend (6) — higher-priority than language detections ──────────────────
+  // ── Backend (5) — higher-priority than language detections ──────────────────
   {
     name: 'be-nestjs-expert',
     category: 'backend',


### PR DESCRIPTION
## Summary
- `propose-upstream.yml`의 커밋 스캔 범위를 merge-base diff → push event range로 축소
- `github.event.before..after`를 사용하여 실제 트리거 커밋만 스캔
- 과거 릴리즈의 커밋 메시지가 현재 push에 오탐으로 매칭되는 문제 해결
- `agent-catalog.ts`의 stale 코멘트 수정 (Backend 6→5)

## Context
`/research` 검증 결과:
- propose-upstream.yml의 push 트리거 3건 중 2건이 false positive (67% 오탐률)
- 원인: merge-base 기반 diff가 과거 feature 커밋까지 포함
- 수정 후: push event 범위만 스캔하여 오탐 제거

## Related Issues
- Closes #129

## Test plan
- [ ] CI checks 통과
- [ ] `bun test` 전체 통과 확인
- [ ] workflow YAML syntax 유효성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)