### PR TITLE
feat: v0.8.0 — doctor framework, protected files, version checker, path centralization

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
         "bun-types": "^1.3.10",
         "husky": "^9.1.7",
         "lint-staged": "^16.3.2",
-        "oh-my-customcode": "^0.31.1",
+        "oh-my-customcode": "^0.32.0",
       },
       "peerDependencies": {
         "oh-my-customcode": ">=0.23.0",
@@ -89,7 +89,7 @@
 
     "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 
-    "oh-my-customcode": ["oh-my-customcode@0.31.1", "", { "dependencies": { "commander": "^14.0.2", "i18next": "^25.8.0", "yaml": "^2.8.2" }, "bin": { "omcustom": "dist/cli/index.js" } }, "sha512-U0oy2JOVlo6q7ltB2MveCz+KCsgNCL2jvl+59pB+gsaPjMt+x57eXY4vv81nMMrcDwe7xD1Z5KNRbjJaq/us+Q=="],
+    "oh-my-customcode": ["oh-my-customcode@0.32.0", "", { "dependencies": { "commander": "^14.0.2", "i18next": "^25.8.0", "yaml": "^2.8.2" }, "bin": { "omcustom": "dist/cli/index.js" } }, "sha512-jLWtct82ahyf4X61yaVBmykTxaxvi8KIJZfnNIJ0phBBHpXpiHA+WTSrkZFETWcTaZ7e87/vd/j0Qt6nwZg9UA=="],
 
     "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 

--- a/docs/superpowers/plans/2026-03-13-issue-134-v032-adapt.md
+++ b/docs/superpowers/plans/2026-03-13-issue-134-v032-adapt.md
@@ -1,0 +1,1565 @@
+# Issue #134: oh-my-customcode v0.32.0 Feature Adaptation
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Adapt oh-my-customcode v0.32.0 features (doctor framework, protected files, version check, session advisory) into oh-my-teammates as native implementations.
+
+**Architecture:** New `doctor` CLI subcommand framework that aggregates health checks across team config, steward coverage, file integrity, and version updates. Centralized path constants eliminate 18 scattered literals. A lockfile manager provides checksum-based file protection for critical team files. Version checking uses Bun's native `fetch` against npm registry with 5s timeout.
+
+**Tech Stack:** TypeScript, Bun runtime, bun:test, bun:sqlite, node:crypto (SHA-256), native fetch API
+
+**Issue:** https://github.com/baekenough/oh-my-teammates/issues/134
+
+---
+
+## File Structure
+
+### New Files
+
+| File | Responsibility |
+|------|----------------|
+| `src/paths.ts` | Centralized team directory path constants (`TEAM_DIR`, `TEAM_PATHS`) |
+| `src/version-checker.ts` | npm registry version check with fetch + timeout + sanitization |
+| `src/doctor.ts` | Doctor subcommand framework: `--config`, `--stewards`, `--updates`, `--locks` |
+| `src/lockfile.ts` | Checksum manifest manager for protected files |
+| `src/__tests__/version-checker.test.ts` | Version checker unit tests |
+| `src/__tests__/doctor.test.ts` | Doctor command integration tests |
+| `src/__tests__/lockfile.test.ts` | Lockfile manager unit tests |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `src/cli.ts` | Add `case 'doctor'`, update usage text |
+| `src/index.ts` | Export new modules |
+| `src/init.ts` | Use `TEAM_PATHS`, add lockfile registration after init |
+| `src/session-logger.ts` | Use `TEAM_PATHS` default |
+| `src/report.ts` | Use `TEAM_PATHS` for all path resolution |
+| `src/team-todo.ts` | Use `TEAM_PATHS` defaults |
+| `src/team-config.ts` | Use `TEAM_PATHS` default |
+| `src/stewards.ts` | Use `TEAM_PATHS` default |
+| `src/report-template.ts` | Update stale `VERSION` constant |
+| `package.json` | Bump devDep `oh-my-customcode` to `^0.32.0`, bump version |
+| `templates/.github/workflows/guardian.yml` | Add protected files validation step |
+
+---
+
+## Chunk 1: Foundation — Path Constants & devDep Bump
+
+### Task 1: Create centralized path constants
+
+**Files:**
+- Create: `src/paths.ts`
+
+- [ ] **Step 1: Create `src/paths.ts`**
+
+```typescript
+// src/paths.ts
+/**
+ * Centralized path constants for team directory structure.
+ * All team-related file paths derive from TEAM_DIR.
+ */
+
+export const TEAM_DIR = '.claude/team' as const;
+
+export const TEAM_PATHS = {
+  TEAM_YAML: `${TEAM_DIR}/team.yaml`,
+  STEWARDS_YAML: `${TEAM_DIR}/STEWARDS.yaml`,
+  TODO_MD: `${TEAM_DIR}/TODO.md`,
+  SESSIONS_DB: `${TEAM_DIR}/sessions.db`,
+  REPORT_HTML: `${TEAM_DIR}/report.html`,
+  LOCKFILE: `${TEAM_DIR}/.lockfile.json`,
+} as const;
+
+export type TeamPathKey = keyof typeof TEAM_PATHS;
+```
+
+- [ ] **Step 2: Verify the file compiles**
+
+Run: `bunx tsc --noEmit src/paths.ts`
+Expected: No errors
+
+---
+
+### Task 2: Migrate existing files to use TEAM_PATHS
+
+**Files:**
+- Modify: `src/session-logger.ts:52` (constructor default)
+- Modify: `src/team-config.ts:27` (constructor default)
+- Modify: `src/stewards.ts` (constructor default — find the line with `configPath = 'STEWARDS.yaml'`)
+- Modify: `src/team-todo.ts` (constructor and STEWARDS.yaml reference)
+- Modify: `src/report.ts:31,89,111,134,170` (all resolve calls)
+- Modify: `src/cli.ts:81,107,199-200` (hardcoded path references)
+- Modify: `src/init.ts:287,290,376,383` (join calls for team paths)
+
+- [ ] **Step 1: Update `src/session-logger.ts`**
+
+Change constructor default from `'.claude/team/sessions.db'` to import from paths:
+```typescript
+import { TEAM_PATHS } from './paths';
+// ...
+constructor(dbPath = TEAM_PATHS.SESSIONS_DB) {
+```
+
+- [ ] **Step 2: Update `src/team-config.ts`**
+
+Change constructor default from `'team.yaml'` to:
+```typescript
+import { TEAM_PATHS } from './paths';
+// ...
+constructor(configPath = TEAM_PATHS.TEAM_YAML) {
+```
+
+> **Note:** Existing tests in `team-config.test.ts` always pass explicit paths via `configPath` variable, so this default change is safe. Verify with `bun test src/__tests__/team-config.test.ts` after this step.
+
+- [ ] **Step 3: Update `src/stewards.ts`**
+
+Change constructor default to:
+```typescript
+import { TEAM_PATHS } from './paths';
+// ...
+constructor(configPath = TEAM_PATHS.STEWARDS_YAML) {
+```
+
+- [ ] **Step 4: Update `src/team-todo.ts`**
+
+Update the constructor default and STEWARDS.yaml reference to use `TEAM_PATHS`.
+
+- [ ] **Step 5: Update `src/report.ts`**
+
+Replace all 5 hardcoded path resolve calls:
+```typescript
+import { TEAM_DIR, TEAM_PATHS } from './paths';
+// line 31: options.output ?? TEAM_PATHS.REPORT_HTML
+// line 89: resolve(this.basePath, TEAM_PATHS.TEAM_YAML)
+// line 111: resolve(this.basePath, TEAM_PATHS.STEWARDS_YAML)
+// line 134: resolve(this.basePath, TEAM_PATHS.TODO_MD)
+// line 170: resolve(this.basePath, TEAM_PATHS.SESSIONS_DB)
+```
+
+- [ ] **Step 6: Update `src/cli.ts`**
+
+Replace hardcoded paths:
+```typescript
+import { TEAM_PATHS } from './paths';
+// line 81: '.claude/team/TODO.md' → TEAM_PATHS.TODO_MD
+// line 107: '.claude/team/sessions.db' → TEAM_PATHS.SESSIONS_DB
+// lines 199-200: '.claude/team/sessions.db' → TEAM_PATHS.SESSIONS_DB
+```
+
+- [ ] **Step 7: Update `src/init.ts`**
+
+Replace join-constructed paths with TEAM_PATHS where applicable:
+```typescript
+import { TEAM_DIR, TEAM_PATHS } from './paths';
+// line 287: join(rootDir, '.claude', 'team') → join(rootDir, TEAM_DIR)
+// line 290: join(teamDir, 'TODO.md') — keep as join since it's relative to teamDir
+// line 376: join(rootDir, '.claude', 'team', 'team.yaml') → join(rootDir, TEAM_PATHS.TEAM_YAML)
+// line 383: join(rootDir, '.claude', 'team', 'STEWARDS.yaml') → join(rootDir, TEAM_PATHS.STEWARDS_YAML)
+```
+
+- [ ] **Step 8: Run all tests to verify no regressions**
+
+Run: `bun test`
+Expected: All tests pass (334+)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/paths.ts src/session-logger.ts src/team-config.ts src/stewards.ts src/team-todo.ts src/report.ts src/cli.ts src/init.ts
+git commit -m "refactor: centralize team directory paths into src/paths.ts
+
+Extract 18 scattered path literals across 7 files into a single
+TEAM_PATHS constant module. Reduces risk of path drift between
+modules and prepares for lockfile/doctor features.
+
+Refs: #134"
+```
+
+---
+
+### Task 3: Fix stale VERSION constant and bump devDep
+
+**Files:**
+- Modify: `src/report-template.ts:6`
+- Modify: `package.json:42`
+
+- [ ] **Step 1: Fix stale VERSION in report-template.ts**
+
+```typescript
+// line 6: change from '0.5.0' to '0.8.0'
+const VERSION = '0.8.0';
+```
+
+Note: This will be the target release version. Known issue: VERSION is hardcoded because `createRequire` causes CI failures on Linux (documented in MEMORY.md).
+
+- [ ] **Step 2: Bump devDep oh-my-customcode**
+
+In `package.json`, change:
+```json
+"oh-my-customcode": "^0.32.0"
+```
+
+- [ ] **Step 3: Run `bun install` and verify lockfile updates**
+
+Run: `bun install`
+Expected: `bun.lock` updated
+
+- [ ] **Step 4: Run tests**
+
+Run: `bun test`
+Expected: All pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add package.json bun.lock src/report-template.ts
+git commit -m "chore: bump oh-my-customcode devDep to ^0.32.0, fix stale VERSION
+
+Update devDependencies to track oh-my-customcode v0.32.0 features.
+Fix report-template.ts VERSION from stale 0.5.0 to 0.8.0.
+
+Refs: #134"
+```
+
+---
+
+## Chunk 2: Version Checker Module
+
+### Task 4: Write version-checker tests (TDD)
+
+**Files:**
+- Create: `src/__tests__/version-checker.test.ts`
+
+- [ ] **Step 1: Write failing tests for version checker**
+
+```typescript
+// src/__tests__/version-checker.test.ts
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+
+describe('checkForUpdate', () => {
+  let fetchSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = spyOn(globalThis, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it('returns updateAvailable: true when registry version is newer', async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ version: '1.0.0' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const { checkForUpdate } = await import('../version-checker');
+    const result = await checkForUpdate('test-pkg', '0.7.2');
+
+    expect(result).toEqual({
+      current: '0.7.2',
+      latest: '1.0.0',
+      updateAvailable: true,
+    });
+  });
+
+  it('returns updateAvailable: false when at latest version', async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ version: '0.7.2' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const { checkForUpdate } = await import('../version-checker');
+    const result = await checkForUpdate('test-pkg', '0.7.2');
+
+    expect(result).toEqual({
+      current: '0.7.2',
+      latest: '0.7.2',
+      updateAvailable: false,
+    });
+  });
+
+  it('returns null on fetch failure', async () => {
+    fetchSpy.mockRejectedValue(new Error('Network error'));
+
+    const { checkForUpdate } = await import('../version-checker');
+    const result = await checkForUpdate('test-pkg', '0.7.2');
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null on non-200 response', async () => {
+    fetchSpy.mockResolvedValue(new Response('Not found', { status: 404 }));
+
+    const { checkForUpdate } = await import('../version-checker');
+    const result = await checkForUpdate('test-pkg', '0.7.2');
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null on malformed JSON', async () => {
+    fetchSpy.mockResolvedValue(
+      new Response('not json', { status: 200, headers: { 'Content-Type': 'text/plain' } }),
+    );
+
+    const { checkForUpdate } = await import('../version-checker');
+    const result = await checkForUpdate('test-pkg', '0.7.2');
+
+    expect(result).toBeNull();
+  });
+
+  it('sanitizes version string (strips non-semver chars)', async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ version: '1.0.0\x1b[31m' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const { checkForUpdate } = await import('../version-checker');
+    const result = await checkForUpdate('test-pkg', '0.7.2');
+
+    expect(result?.latest).toBe('1.0.0');
+    expect(result?.updateAvailable).toBe(true);
+  });
+});
+
+describe('compareSemver', () => {
+  it('correctly compares major versions', async () => {
+    const { compareSemver } = await import('../version-checker');
+    expect(compareSemver('2.0.0', '1.0.0')).toBeGreaterThan(0);
+    expect(compareSemver('1.0.0', '2.0.0')).toBeLessThan(0);
+  });
+
+  it('correctly compares minor versions', async () => {
+    const { compareSemver } = await import('../version-checker');
+    expect(compareSemver('1.1.0', '1.0.0')).toBeGreaterThan(0);
+  });
+
+  it('correctly compares patch versions', async () => {
+    const { compareSemver } = await import('../version-checker');
+    expect(compareSemver('1.0.1', '1.0.0')).toBeGreaterThan(0);
+  });
+
+  it('returns 0 for equal versions', async () => {
+    const { compareSemver } = await import('../version-checker');
+    expect(compareSemver('1.0.0', '1.0.0')).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test src/__tests__/version-checker.test.ts`
+Expected: FAIL — module not found
+
+---
+
+### Task 5: Implement version checker
+
+**Files:**
+- Create: `src/version-checker.ts`
+
+- [ ] **Step 1: Implement version-checker.ts**
+
+```typescript
+// src/version-checker.ts
+/**
+ * npm registry version checker.
+ * First runtime network call in oh-my-teammates — designed for safety:
+ * - 5 second timeout (not blocking CLI for slow networks)
+ * - Response size bounded (reject > 10KB)
+ * - Version string sanitized (strip non-semver chars)
+ * - Graceful null return on any failure
+ */
+
+export interface UpdateCheckResult {
+  current: string;
+  latest: string;
+  updateAvailable: boolean;
+}
+
+const REGISTRY_TIMEOUT_MS = 5000;
+const MAX_RESPONSE_SIZE = 10 * 1024; // 10KB
+
+/**
+ * Compare two semver strings. Returns:
+ *   > 0 if a > b
+ *   < 0 if a < b
+ *   0   if a === b
+ */
+export function compareSemver(a: string, b: string): number {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+
+  for (let i = 0; i < 3; i++) {
+    const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+/**
+ * Strip non-semver characters from a version string.
+ * Prevents terminal escape code injection.
+ */
+function sanitizeVersion(version: string): string {
+  const match = version.match(/^(\d+\.\d+\.\d+)/);
+  return match ? match[1] : '';
+}
+
+/**
+ * Check npm registry for the latest version of a package.
+ * Returns null on any failure (network, timeout, malformed response).
+ */
+export async function checkForUpdate(
+  packageName: string,
+  currentVersion: string,
+): Promise<UpdateCheckResult | null> {
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), REGISTRY_TIMEOUT_MS);
+
+    const response = await fetch(
+      `https://registry.npmjs.org/${encodeURIComponent(packageName)}/latest`,
+      {
+        headers: { Accept: 'application/json' },
+        signal: controller.signal,
+      },
+    );
+
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      return null;
+    }
+
+    // Bound response size
+    const contentLength = response.headers.get('content-length');
+    if (contentLength && Number.parseInt(contentLength, 10) > MAX_RESPONSE_SIZE) {
+      return null;
+    }
+
+    const text = await response.text();
+    if (text.length > MAX_RESPONSE_SIZE) {
+      return null;
+    }
+
+    const data: unknown = JSON.parse(text);
+    if (typeof data !== 'object' || data === null || !('version' in data)) {
+      return null;
+    }
+
+    const rawVersion = (data as { version: unknown }).version;
+    if (typeof rawVersion !== 'string') {
+      return null;
+    }
+
+    const latest = sanitizeVersion(rawVersion);
+    if (!latest) {
+      return null;
+    }
+
+    return {
+      current: currentVersion,
+      latest,
+      updateAvailable: compareSemver(latest, currentVersion) > 0,
+    };
+  } catch {
+    return null;
+  }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `bun test src/__tests__/version-checker.test.ts`
+Expected: All pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/version-checker.ts src/__tests__/version-checker.test.ts
+git commit -m "feat: add npm registry version checker with safety guards
+
+Implement checkForUpdate() with 5s timeout, 10KB response cap,
+version string sanitization, and graceful null-on-failure.
+First runtime network call in oh-my-teammates.
+
+Refs: #134"
+```
+
+---
+
+## Chunk 3: Lockfile Manager
+
+### Task 6: Write lockfile tests (TDD)
+
+**Files:**
+- Create: `src/__tests__/lockfile.test.ts`
+
+- [ ] **Step 1: Write failing tests for lockfile manager**
+
+```typescript
+// src/__tests__/lockfile.test.ts
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+function makeTempDir(): string {
+  const dir = join(tmpdir(), `lockfile-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function cleanup(dir: string): void {
+  try {
+    rmSync(dir, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+}
+
+describe('LockfileManager', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+    mkdirSync(join(tmpDir, '.claude', 'team'), { recursive: true });
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  it('lock() creates .lockfile.json with correct hash', async () => {
+    const { LockfileManager } = await import('../lockfile');
+    const filePath = join(tmpDir, '.claude', 'team', 'team.yaml');
+    writeFileSync(filePath, 'team: test\n', 'utf-8');
+
+    const manager = new LockfileManager(tmpDir);
+    manager.lock(filePath);
+
+    const lockfilePath = join(tmpDir, '.claude', 'team', '.lockfile.json');
+    expect(existsSync(lockfilePath)).toBe(true);
+
+    const lockData = JSON.parse(readFileSync(lockfilePath, 'utf-8'));
+    expect(lockData).toHaveProperty(filePath);
+    expect(lockData[filePath].hash).toMatch(/^[a-f0-9]{64}$/); // SHA-256
+  });
+
+  it('verify() returns ok: true for unchanged file', async () => {
+    const { LockfileManager } = await import('../lockfile');
+    const filePath = join(tmpDir, '.claude', 'team', 'team.yaml');
+    writeFileSync(filePath, 'team: test\n', 'utf-8');
+
+    const manager = new LockfileManager(tmpDir);
+    manager.lock(filePath);
+
+    const result = manager.verify(filePath);
+    expect(result.ok).toBe(true);
+  });
+
+  it('verify() returns ok: false for modified file', async () => {
+    const { LockfileManager } = await import('../lockfile');
+    const filePath = join(tmpDir, '.claude', 'team', 'team.yaml');
+    writeFileSync(filePath, 'team: test\n', 'utf-8');
+
+    const manager = new LockfileManager(tmpDir);
+    manager.lock(filePath);
+
+    // Modify the file
+    writeFileSync(filePath, 'team: modified\n', 'utf-8');
+
+    const result = manager.verify(filePath);
+    expect(result.ok).toBe(false);
+    expect(result).toHaveProperty('expected');
+    expect(result).toHaveProperty('actual');
+  });
+
+  it('unlock() removes entry from lockfile', async () => {
+    const { LockfileManager } = await import('../lockfile');
+    const filePath = join(tmpDir, '.claude', 'team', 'team.yaml');
+    writeFileSync(filePath, 'team: test\n', 'utf-8');
+
+    const manager = new LockfileManager(tmpDir);
+    manager.lock(filePath);
+    manager.unlock(filePath);
+
+    const result = manager.verify(filePath);
+    expect(result.ok).toBe(true); // no lock = ok (nothing to verify)
+  });
+
+  it('verifyAll() checks all locked paths', async () => {
+    const { LockfileManager } = await import('../lockfile');
+
+    const file1 = join(tmpDir, '.claude', 'team', 'team.yaml');
+    const file2 = join(tmpDir, '.claude', 'team', 'STEWARDS.yaml');
+    writeFileSync(file1, 'team: test\n', 'utf-8');
+    writeFileSync(file2, 'stewards: test\n', 'utf-8');
+
+    const manager = new LockfileManager(tmpDir);
+    manager.lock(file1);
+    manager.lock(file2);
+
+    // Modify one file
+    writeFileSync(file2, 'stewards: changed\n', 'utf-8');
+
+    const results = manager.verifyAll();
+    expect(results.length).toBe(2);
+
+    const okResults = [];
+    const failResults = [];
+    for (const r of results) {
+      if (r.ok) okResults.push(r);
+      else failResults.push(r);
+    }
+    expect(okResults.length).toBe(1);
+    expect(failResults.length).toBe(1);
+  });
+
+  it('handles missing .lockfile.json gracefully', async () => {
+    const { LockfileManager } = await import('../lockfile');
+    const manager = new LockfileManager(tmpDir);
+
+    const result = manager.verifyAll();
+    expect(result).toEqual([]);
+  });
+
+  it('handles missing locked file gracefully', async () => {
+    const { LockfileManager } = await import('../lockfile');
+    const filePath = join(tmpDir, '.claude', 'team', 'team.yaml');
+    writeFileSync(filePath, 'team: test\n', 'utf-8');
+
+    const manager = new LockfileManager(tmpDir);
+    manager.lock(filePath);
+
+    // Delete the locked file
+    rmSync(filePath);
+
+    const result = manager.verify(filePath);
+    expect(result.ok).toBe(false);
+  });
+
+  it('lock is idempotent (lock same file twice updates hash)', async () => {
+    const { LockfileManager } = await import('../lockfile');
+    const filePath = join(tmpDir, '.claude', 'team', 'team.yaml');
+    writeFileSync(filePath, 'team: v1\n', 'utf-8');
+
+    const manager = new LockfileManager(tmpDir);
+    manager.lock(filePath);
+
+    writeFileSync(filePath, 'team: v2\n', 'utf-8');
+    manager.lock(filePath);
+
+    const result = manager.verify(filePath);
+    expect(result.ok).toBe(true); // re-locked with new content
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test src/__tests__/lockfile.test.ts`
+Expected: FAIL — module not found
+
+---
+
+### Task 7: Implement lockfile manager
+
+**Files:**
+- Create: `src/lockfile.ts`
+
+- [ ] **Step 1: Implement lockfile.ts**
+
+```typescript
+// src/lockfile.ts
+/**
+ * Checksum-based file protection for team configuration files.
+ * Tracks SHA-256 hashes of critical files to detect accidental overwrites.
+ */
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { TEAM_PATHS } from './paths';
+
+export interface LockEntry {
+  hash: string;
+  lockedAt: string;
+}
+
+export interface VerifyResult {
+  path: string;
+  ok: boolean;
+  expected?: string;
+  actual?: string;
+}
+
+type LockData = Record<string, LockEntry>;
+
+export class LockfileManager {
+  private lockfilePath: string;
+
+  constructor(basePath = '.') {
+    this.lockfilePath = join(basePath, TEAM_PATHS.LOCKFILE);
+  }
+
+  private computeHash(filePath: string): string {
+    const content = readFileSync(filePath, 'utf-8');
+    return createHash('sha256').update(content).digest('hex');
+  }
+
+  private readLockData(): LockData {
+    if (!existsSync(this.lockfilePath)) {
+      return {};
+    }
+    try {
+      return JSON.parse(readFileSync(this.lockfilePath, 'utf-8')) as LockData;
+    } catch {
+      return {};
+    }
+  }
+
+  private writeLockData(data: LockData): void {
+    writeFileSync(this.lockfilePath, JSON.stringify(data, null, 2), 'utf-8');
+  }
+
+  /**
+   * Lock a file by recording its SHA-256 hash.
+   * Idempotent: re-locking updates the hash to match current content.
+   */
+  lock(filePath: string): void {
+    const data = this.readLockData();
+    data[filePath] = {
+      hash: this.computeHash(filePath),
+      lockedAt: new Date().toISOString(),
+    };
+    this.writeLockData(data);
+  }
+
+  /**
+   * Verify a locked file's integrity.
+   * Returns ok: true if file matches stored hash, or if file has no lock entry.
+   */
+  verify(filePath: string): VerifyResult {
+    const data = this.readLockData();
+    const entry = data[filePath];
+
+    if (!entry) {
+      return { path: filePath, ok: true };
+    }
+
+    if (!existsSync(filePath)) {
+      return {
+        path: filePath,
+        ok: false,
+        expected: entry.hash,
+        actual: '(file missing)',
+      };
+    }
+
+    const currentHash = this.computeHash(filePath);
+    if (currentHash === entry.hash) {
+      return { path: filePath, ok: true };
+    }
+
+    return {
+      path: filePath,
+      ok: false,
+      expected: entry.hash,
+      actual: currentHash,
+    };
+  }
+
+  /**
+   * Verify all locked files. Uses for loop instead of .filter() for Linux coverage.
+   */
+  verifyAll(): VerifyResult[] {
+    const data = this.readLockData();
+    const results: VerifyResult[] = [];
+    for (const filePath of Object.keys(data)) {
+      results.push(this.verify(filePath));
+    }
+    return results;
+  }
+
+  /**
+   * Remove a file's lock entry.
+   */
+  unlock(filePath: string): void {
+    const data = this.readLockData();
+    delete data[filePath];
+    this.writeLockData(data);
+  }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `bun test src/__tests__/lockfile.test.ts`
+Expected: All pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lockfile.ts src/__tests__/lockfile.test.ts
+git commit -m "feat: add checksum-based lockfile manager for team file protection
+
+Implement LockfileManager with SHA-256 hash tracking, verify/verifyAll
+for integrity checks, and lock/unlock operations. Protects team.yaml
+and STEWARDS.yaml from accidental overwrites.
+
+Refs: #134"
+```
+
+---
+
+## Chunk 4: Doctor Command Framework
+
+### Task 8: Write doctor command tests (TDD)
+
+**Files:**
+- Create: `src/__tests__/doctor.test.ts`
+
+- [ ] **Step 1: Write failing tests for doctor module**
+
+```typescript
+// src/__tests__/doctor.test.ts
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+function makeTempDir(): string {
+  const dir = join(tmpdir(), `doctor-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function cleanup(dir: string): void {
+  try {
+    rmSync(dir, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+}
+
+describe('runDoctor', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  it('--config check passes with valid team.yaml', async () => {
+    const { runDoctor } = await import('../doctor');
+    mkdirSync(join(tmpDir, '.claude', 'team'), { recursive: true });
+    writeFileSync(
+      join(tmpDir, '.claude', 'team', 'team.yaml'),
+      'team:\n  name: test\n  version: "1.0"\n  members:\n    - github: user1\n      name: User 1\n      role: admin\n      domains: []\n',
+      'utf-8',
+    );
+
+    const results = await runDoctor({ config: true }, tmpDir);
+
+    const configResult = results.find((r) => r.check === 'team.yaml');
+    expect(configResult?.status).toBe('pass');
+  });
+
+  it('--config check fails when team.yaml missing', async () => {
+    const { runDoctor } = await import('../doctor');
+
+    const results = await runDoctor({ config: true }, tmpDir);
+
+    const configResult = results.find((r) => r.check === 'team.yaml');
+    expect(configResult?.status).toBe('fail');
+  });
+
+  it('--stewards check detects coverage gaps', async () => {
+    const { runDoctor } = await import('../doctor');
+    mkdirSync(join(tmpDir, '.claude', 'team'), { recursive: true });
+    writeFileSync(
+      join(tmpDir, '.claude', 'team', 'STEWARDS.yaml'),
+      'stewards:\n  version: "1.0"\n  domains:\n    backend:\n      primary: user1\n      backup: null\n      paths:\n        - src/api/**\n',
+      'utf-8',
+    );
+
+    const results = await runDoctor({ stewards: true }, tmpDir);
+
+    const gapResult = results.find((r) => r.check === 'steward-coverage');
+    expect(gapResult?.status).toBe('warn');
+    expect(gapResult?.message).toContain('backend');
+  });
+
+  it('--stewards check passes with full coverage', async () => {
+    const { runDoctor } = await import('../doctor');
+    mkdirSync(join(tmpDir, '.claude', 'team'), { recursive: true });
+    writeFileSync(
+      join(tmpDir, '.claude', 'team', 'STEWARDS.yaml'),
+      'stewards:\n  version: "1.0"\n  domains:\n    backend:\n      primary: user1\n      backup: user2\n      paths:\n        - src/api/**\n',
+      'utf-8',
+    );
+
+    const results = await runDoctor({ stewards: true }, tmpDir);
+
+    const gapResult = results.find((r) => r.check === 'steward-coverage');
+    expect(gapResult?.status).toBe('pass');
+  });
+
+  it('--locks check detects modified locked files', async () => {
+    const { runDoctor } = await import('../doctor');
+    const { LockfileManager } = await import('../lockfile');
+
+    mkdirSync(join(tmpDir, '.claude', 'team'), { recursive: true });
+    const teamYaml = join(tmpDir, '.claude', 'team', 'team.yaml');
+    writeFileSync(teamYaml, 'team: original\n', 'utf-8');
+
+    const lockMgr = new LockfileManager(tmpDir);
+    lockMgr.lock(teamYaml);
+
+    // Modify the file
+    writeFileSync(teamYaml, 'team: modified\n', 'utf-8');
+
+    const results = await runDoctor({ locks: true }, tmpDir);
+
+    const lockResult = results.find((r) => r.check === 'file-integrity');
+    expect(lockResult?.status).toBe('fail');
+  });
+
+  it('--locks check passes when no modifications', async () => {
+    const { runDoctor } = await import('../doctor');
+    const { LockfileManager } = await import('../lockfile');
+
+    mkdirSync(join(tmpDir, '.claude', 'team'), { recursive: true });
+    const teamYaml = join(tmpDir, '.claude', 'team', 'team.yaml');
+    writeFileSync(teamYaml, 'team: original\n', 'utf-8');
+
+    const lockMgr = new LockfileManager(tmpDir);
+    lockMgr.lock(teamYaml);
+
+    const results = await runDoctor({ locks: true }, tmpDir);
+
+    const lockResult = results.find((r) => r.check === 'file-integrity');
+    expect(lockResult?.status).toBe('pass');
+  });
+
+  it('returns all checks when no flags specified', async () => {
+    const { runDoctor } = await import('../doctor');
+
+    const results = await runDoctor({}, tmpDir);
+
+    // Should run at least config, stewards, and locks checks
+    expect(results.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('--updates check shows update available', async () => {
+    const vcModule = await import('../version-checker');
+    const spy = spyOn(vcModule, 'checkForUpdate').mockResolvedValue({
+      current: '0.8.0',
+      latest: '0.9.0',
+      updateAvailable: true,
+    });
+
+    const { runDoctor } = await import('../doctor');
+    const results = await runDoctor({ updates: true }, tmpDir);
+
+    const r = results.find((r) => r.check === 'updates');
+    expect(r?.status).toBe('warn');
+    expect(r?.message).toContain('0.9.0');
+    spy.mockRestore();
+  });
+
+  it('--updates check shows up to date', async () => {
+    const vcModule = await import('../version-checker');
+    const spy = spyOn(vcModule, 'checkForUpdate').mockResolvedValue({
+      current: '0.8.0',
+      latest: '0.8.0',
+      updateAvailable: false,
+    });
+
+    const { runDoctor } = await import('../doctor');
+    const results = await runDoctor({ updates: true }, tmpDir);
+
+    const r = results.find((r) => r.check === 'updates');
+    expect(r?.status).toBe('pass');
+    spy.mockRestore();
+  });
+
+  it('--updates check handles network failure gracefully', async () => {
+    const vcModule = await import('../version-checker');
+    const spy = spyOn(vcModule, 'checkForUpdate').mockResolvedValue(null);
+
+    const { runDoctor } = await import('../doctor');
+    const results = await runDoctor({ updates: true }, tmpDir);
+
+    const r = results.find((r) => r.check === 'updates');
+    expect(r?.status).toBe('warn');
+    expect(r?.message).toContain('network');
+    spy.mockRestore();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test src/__tests__/doctor.test.ts`
+Expected: FAIL — module not found
+
+---
+
+### Task 9: Implement doctor module
+
+**Files:**
+- Create: `src/doctor.ts`
+
+- [ ] **Step 1: Implement doctor.ts**
+
+```typescript
+// src/doctor.ts
+/**
+ * Team health check framework.
+ * Aggregates validation from TeamConfig, Stewards, and LockfileManager.
+ */
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { LockfileManager } from './lockfile';
+import { TEAM_PATHS } from './paths';
+import { Stewards } from './stewards';
+import { TeamConfig } from './team-config';
+import { checkForUpdate } from './version-checker';
+
+export interface DoctorCheckResult {
+  check: string;
+  status: 'pass' | 'warn' | 'fail';
+  message: string;
+}
+
+export interface DoctorOptions {
+  config?: boolean;
+  stewards?: boolean;
+  updates?: boolean;
+  locks?: boolean;
+}
+
+const PACKAGE_NAME = '@oh-my-customcode/oh-my-teammates';
+const CURRENT_VERSION = '0.8.0';
+
+export async function runDoctor(
+  options: DoctorOptions,
+  basePath = '.',
+): Promise<DoctorCheckResult[]> {
+  const results: DoctorCheckResult[] = [];
+  const runAll = !options.config && !options.stewards && !options.updates && !options.locks;
+
+  if (runAll || options.config) {
+    results.push(...checkConfig(basePath));
+  }
+
+  if (runAll || options.stewards) {
+    results.push(...checkStewards(basePath));
+  }
+
+  if (runAll || options.locks) {
+    results.push(...checkLocks(basePath));
+  }
+
+  if (options.updates) {
+    const updateResult = await checkUpdates();
+    if (updateResult) {
+      results.push(updateResult);
+    }
+  }
+
+  return results;
+}
+
+function checkConfig(basePath: string): DoctorCheckResult[] {
+  const results: DoctorCheckResult[] = [];
+  const teamYamlPath = join(basePath, TEAM_PATHS.TEAM_YAML);
+
+  if (!existsSync(teamYamlPath)) {
+    results.push({
+      check: 'team.yaml',
+      status: 'fail',
+      message: `${TEAM_PATHS.TEAM_YAML} not found. Run 'omcustom-team init' first.`,
+    });
+    return results;
+  }
+
+  try {
+    const config = new TeamConfig(teamYamlPath);
+    const data = config.load();
+    results.push({
+      check: 'team.yaml',
+      status: 'pass',
+      message: `Valid (${data.team.members.length} members)`,
+    });
+  } catch (err) {
+    results.push({
+      check: 'team.yaml',
+      status: 'fail',
+      message: `Invalid: ${err instanceof Error ? err.message : String(err)}`,
+    });
+  }
+
+  return results;
+}
+
+function checkStewards(basePath: string): DoctorCheckResult[] {
+  const results: DoctorCheckResult[] = [];
+  const stewardsPath = join(basePath, TEAM_PATHS.STEWARDS_YAML);
+
+  if (!existsSync(stewardsPath)) {
+    results.push({
+      check: 'STEWARDS.yaml',
+      status: 'fail',
+      message: `${TEAM_PATHS.STEWARDS_YAML} not found. Run 'omcustom-team init' first.`,
+    });
+    return results;
+  }
+
+  try {
+    const stewards = new Stewards(stewardsPath);
+    stewards.load();
+    const domains = stewards.getDomains();
+
+    results.push({
+      check: 'STEWARDS.yaml',
+      status: 'pass',
+      message: `Valid (${Object.keys(domains).length} domains)`,
+    });
+
+    // Check coverage gaps
+    const gaps: string[] = [];
+    for (const [domain, steward] of Object.entries(domains)) {
+      if (steward.backup === null) {
+        gaps.push(domain);
+      }
+    }
+
+    if (gaps.length > 0) {
+      results.push({
+        check: 'steward-coverage',
+        status: 'warn',
+        message: `${gaps.length} domain(s) without backup steward: ${gaps.join(', ')}`,
+      });
+    } else {
+      results.push({
+        check: 'steward-coverage',
+        status: 'pass',
+        message: 'All domains have backup stewards',
+      });
+    }
+  } catch (err) {
+    results.push({
+      check: 'STEWARDS.yaml',
+      status: 'fail',
+      message: `Invalid: ${err instanceof Error ? err.message : String(err)}`,
+    });
+  }
+
+  return results;
+}
+
+function checkLocks(basePath: string): DoctorCheckResult[] {
+  const manager = new LockfileManager(basePath);
+  const verifyResults = manager.verifyAll();
+
+  if (verifyResults.length === 0) {
+    return [
+      {
+        check: 'file-integrity',
+        status: 'pass',
+        message: 'No locked files to verify',
+      },
+    ];
+  }
+
+  const failures: string[] = [];
+  for (const r of verifyResults) {
+    if (!r.ok) {
+      failures.push(r.path);
+    }
+  }
+
+  if (failures.length > 0) {
+    return [
+      {
+        check: 'file-integrity',
+        status: 'fail',
+        message: `${failures.length} file(s) modified since lock: ${failures.map((f) => f.split('/').pop()).join(', ')}`,
+      },
+    ];
+  }
+
+  return [
+    {
+      check: 'file-integrity',
+      status: 'pass',
+      message: `All ${verifyResults.length} locked file(s) intact`,
+    },
+  ];
+}
+
+async function checkUpdates(): Promise<DoctorCheckResult | null> {
+  const result = await checkForUpdate(PACKAGE_NAME, CURRENT_VERSION);
+
+  if (result === null) {
+    return {
+      check: 'updates',
+      status: 'warn',
+      message: 'Could not check for updates (network unavailable or timeout)',
+    };
+  }
+
+  if (result.updateAvailable) {
+    return {
+      check: 'updates',
+      status: 'warn',
+      message: `Update available: ${result.current} → ${result.latest}`,
+    };
+  }
+
+  return {
+    check: 'updates',
+    status: 'pass',
+    message: `Up to date (${result.current})`,
+  };
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `bun test src/__tests__/doctor.test.ts`
+Expected: All pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/doctor.ts src/__tests__/doctor.test.ts
+git commit -m "feat: add doctor health check framework
+
+Implement runDoctor() with --config, --stewards, --locks, --updates
+checks. Aggregates TeamConfig.validate, Stewards coverage gaps,
+LockfileManager integrity, and npm version checking.
+
+Refs: #134"
+```
+
+---
+
+## Chunk 5: CLI Integration & Init Lockfile Registration
+
+### Task 10: Add doctor case to CLI
+
+**Files:**
+- Modify: `src/cli.ts:227-254` (add case before default, update usage)
+
+- [ ] **Step 1: Add `case 'doctor'` to cli.ts**
+
+Insert before the `default:` case (line 228):
+
+```typescript
+    case 'doctor': {
+      const { runDoctor } = await import('./doctor');
+      const checks = {
+        config: args.includes('--config'),
+        stewards: args.includes('--stewards'),
+        updates: args.includes('--updates'),
+        locks: args.includes('--locks'),
+      };
+
+      const results = await runDoctor(checks);
+
+      for (const r of results) {
+        const icon = r.status === 'pass' ? '\u2713' : r.status === 'warn' ? '!' : '\u2717';
+        console.log(`${icon} [${r.check}] ${r.message}`);
+      }
+
+      const hasFailure = results.some((r) => r.status === 'fail');
+      if (hasFailure) {
+        process.exit(1);
+      }
+      break;
+    }
+```
+
+- [ ] **Step 2: Update usage text in default case**
+
+Update the usage line:
+```typescript
+console.log('Usage: omcustom-team [init|todo|report|recommend|sessions|doctor]');
+```
+
+Add doctor section after Session options:
+```typescript
+console.log('');
+console.log('Doctor options:');
+console.log('    --config             Validate team.yaml');
+console.log('    --stewards           Check steward coverage');
+console.log('    --updates            Check for newer version');
+console.log('    --locks              Verify file integrity');
+```
+
+- [ ] **Step 3: Run CLI test to verify usage text updated**
+
+Run: `bun test src/__tests__/cli.test.ts`
+Expected: Existing test for usage message may need update (check if it matches exact string)
+
+- [ ] **Step 4: Fix any failing test assertions**
+
+Update `cli.test.ts` assertion from:
+```
+'Usage: omcustom-team [init|todo|report|recommend|sessions]'
+```
+to:
+```
+'Usage: omcustom-team [init|todo|report|recommend|sessions|doctor]'
+```
+
+- [ ] **Step 5: Run all tests**
+
+Run: `bun test`
+Expected: All pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cli.ts src/__tests__/cli.test.ts
+git commit -m "feat: add doctor subcommand to CLI
+
+Wire runDoctor() into CLI dispatcher with --config, --stewards,
+--updates, --locks flags. Update usage text. Exit 1 on failures.
+
+Refs: #134"
+```
+
+---
+
+### Task 11: Register lockfile on init
+
+**Files:**
+- Modify: `src/init.ts:393-400` (add step 7 after existing steps)
+
+- [ ] **Step 1: Add lockfile registration to initTeam()**
+
+After the CLAUDE.md scaffolding (step 6), add step 7:
+
+```typescript
+  // 7. Register critical team files in lockfile
+  const { LockfileManager } = await import('./lockfile');
+  const lockMgr = new LockfileManager(rootDir);
+  if (existsSync(teamConfigPath)) {
+    lockMgr.lock(teamConfigPath);
+  }
+  if (existsSync(stewardsPath)) {
+    lockMgr.lock(stewardsPath);
+  }
+```
+
+- [ ] **Step 2: Run init tests to verify**
+
+Run: `bun test src/__tests__/init.test.ts`
+Expected: All pass (lockfile is an additive side-effect, shouldn't break existing assertions)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/init.ts
+git commit -m "feat: register team files in lockfile on init
+
+After scaffolding team.yaml and STEWARDS.yaml, automatically
+lock them with SHA-256 checksums to detect accidental overwrites.
+
+Refs: #134"
+```
+
+---
+
+### Task 12: Export new modules from index.ts
+
+**Files:**
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: Add exports**
+
+```typescript
+export type { UpdateCheckResult } from './version-checker';
+export { checkForUpdate, compareSemver } from './version-checker';
+export type { DoctorCheckResult, DoctorOptions } from './doctor';
+export { runDoctor } from './doctor';
+export type { LockEntry, VerifyResult } from './lockfile';
+export { LockfileManager } from './lockfile';
+export { TEAM_DIR, TEAM_PATHS } from './paths';
+```
+
+- [ ] **Step 2: Run build to verify exports resolve**
+
+Run: `bun run build`
+Expected: Build succeeds, dist/index.js contains new exports
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/index.ts
+git commit -m "feat: export doctor, lockfile, version-checker, paths from index
+
+Make new v0.8.0 modules available as library exports.
+
+Refs: #134"
+```
+
+---
+
+## Chunk 6: Guardian CI Update & Final Validation
+
+### Task 13: Add protected files check to Guardian CI
+
+**Files:**
+- Modify: `templates/.github/workflows/guardian.yml`
+
+- [ ] **Step 1: Add lockfile verification step**
+
+Add after the existing STEWARDS.yaml validation step:
+
+```yaml
+    # ── Protected files integrity check ────────────────────────────────
+    - name: Verify protected file integrity
+      run: |
+        if [ -f "pr/.claude/team/.lockfile.json" ]; then
+          echo "Checking locked file integrity..."
+          cd pr
+          LOCKFILE=".claude/team/.lockfile.json"
+          FAILURES=0
+          for FILE in $(jq -r 'keys[]' "$LOCKFILE" 2>/dev/null); do
+            if [ ! -f "$FILE" ]; then
+              echo "::error::Locked file missing: $FILE"
+              FAILURES=$((FAILURES + 1))
+            fi
+          done
+          if [ "$FAILURES" -gt 0 ]; then
+            echo "::error::$FAILURES locked file(s) have issues"
+            exit 1
+          fi
+          echo "All locked files present"
+        else
+          echo "No lockfile found, skipping integrity check"
+        fi
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add templates/.github/workflows/guardian.yml
+git commit -m "feat: add protected files integrity check to Guardian CI
+
+Verify locked files exist and haven't been deleted in PRs.
+Reads .lockfile.json manifest when present.
+
+Refs: #134"
+```
+
+---
+
+### Task 14: Full test suite and coverage validation
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `bun test`
+Expected: All tests pass (334 + new tests)
+
+- [ ] **Step 2: Check coverage**
+
+Run: `bun test --coverage`
+Expected: 100% function coverage (use for loops, not .filter() on empty arrays)
+
+- [ ] **Step 3: Run lint**
+
+Run: `bun run lint`
+Expected: No errors
+
+- [ ] **Step 4: Run typecheck**
+
+Run: `bunx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 5: Run build**
+
+Run: `bun run build`
+Expected: dist/index.js and dist/cli.js generated
+
+- [ ] **Step 6: Manual smoke test**
+
+```bash
+# From the oh-my-teammates project root:
+bun run dist/cli.js doctor
+bun run dist/cli.js doctor --config
+bun run dist/cli.js doctor --stewards
+bun run dist/cli.js doctor --locks
+```
+
+Expected: Appropriate check results displayed
+
+---
+
+### Task 15: Version bump and final commit
+
+- [ ] **Step 1: Bump version in package.json**
+
+Change `"version": "0.7.2"` to `"version": "0.8.0"`
+
+- [ ] **Step 2: Update CURRENT_VERSION in doctor.ts**
+
+Verify `CURRENT_VERSION` in `src/doctor.ts` matches `0.8.0`.
+
+- [ ] **Step 3: Update VERSION in report-template.ts**
+
+Verify `VERSION` in `src/report-template.ts` matches `0.8.0`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add package.json
+git commit -m "chore: bump version to 0.8.0
+
+Release v0.8.0 with doctor framework, lockfile protection,
+version checker, and centralized path constants.
+
+Closes: #134"
+```
+
+---
+
+## Implementation Summary
+
+| Chunk | Tasks | New Files | Modified Files | Est. LOC |
+|-------|-------|-----------|---------------|----------|
+| 1: Foundation | 1-3 | 1 | 9 | ~80 |
+| 2: Version Checker | 4-5 | 2 | 0 | ~200 |
+| 3: Lockfile Manager | 6-7 | 2 | 0 | ~260 |
+| 4: Doctor Framework | 8-9 | 2 | 0 | ~280 |
+| 5: CLI Integration | 10-12 | 0 | 3 | ~60 |
+| 6: Validation | 13-15 | 0 | 2 | ~30 |
+| **Total** | **15** | **7** | **14** | **~910** |
+
+## Key Implementation Notes
+
+1. **VERSION hardcoding**: Use hardcoded `const VERSION = '0.8.0'` — do NOT use `createRequire` to read package.json dynamically (causes CI failures on Linux per MEMORY.md).
+
+2. **Linux coverage**: Use `for` loops instead of `.filter()` on arrays that may be empty — arrow function callbacks in `.filter()` are counted as uncovered on Linux.
+
+3. **No new dependencies**: All features use Bun-native APIs: `fetch` (version check), `node:crypto` (SHA-256), `node:fs` (lockfile I/O).
+
+4. **doctor --updates is opt-in**: Not included in the default `runDoctor({})` call to avoid network calls without explicit user intent.
+
+5. **Test pattern**: Follow existing `makeTempDir()`/`cleanup()` pattern, `spyOn(globalThis, 'fetch')` for network mocking, `spyOn(process, 'exit')` for CLI exit testing.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oh-my-customcode/oh-my-teammates",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Team collaboration addon for oh-my-customcode - organizational harness management",
   "type": "module",
   "main": "dist/index.js",
@@ -39,7 +39,7 @@
     "bun-types": "^1.3.10",
     "husky": "^9.1.7",
     "lint-staged": "^16.3.2",
-    "oh-my-customcode": "^0.31.1"
+    "oh-my-customcode": "^0.32.0"
   },
   "dependencies": {
     "yaml": "^2.7.0"

--- a/src/__tests__/cli-coverage.test.ts
+++ b/src/__tests__/cli-coverage.test.ts
@@ -169,4 +169,49 @@ describe('runCli coverage', () => {
       promptSpy.mockRestore();
     });
   });
+
+  describe('doctor command', () => {
+    it('runs doctor --locks and prints check results', async () => {
+      const doctorModule = await import('../doctor');
+      const doctorSpy = spyOn(doctorModule, 'runDoctor').mockResolvedValue([
+        { check: 'file-integrity', status: 'pass', message: 'No locked files to verify' },
+      ]);
+
+      const { runCli } = await import('../cli');
+      await runCli(['doctor', '--locks']);
+
+      expect(consoleLogs.some((l) => l.includes('file-integrity'))).toBe(true);
+      doctorSpy.mockRestore();
+    });
+
+    it('exits with code 1 when doctor finds failures', async () => {
+      const doctorModule = await import('../doctor');
+      const doctorSpy = spyOn(doctorModule, 'runDoctor').mockResolvedValue([
+        { check: 'team.yaml', status: 'fail', message: 'not found' },
+      ]);
+
+      const processExitSpy = spyOn(process, 'exit').mockImplementation((code?: number) => {
+        throw new Error(`process.exit(${code})`);
+      });
+
+      const { runCli } = await import('../cli');
+      await expect(runCli(['doctor', '--config'])).rejects.toThrow('process.exit(1)');
+
+      doctorSpy.mockRestore();
+      processExitSpy.mockRestore();
+    });
+
+    it('runs doctor with --updates flag', async () => {
+      const doctorModule = await import('../doctor');
+      const doctorSpy = spyOn(doctorModule, 'runDoctor').mockResolvedValue([
+        { check: 'updates', status: 'pass', message: 'Up to date (0.8.0)' },
+      ]);
+
+      const { runCli } = await import('../cli');
+      await runCli(['doctor', '--updates']);
+
+      expect(consoleLogs.some((l) => l.includes('updates'))).toBe(true);
+      doctorSpy.mockRestore();
+    });
+  });
 });

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -60,7 +60,7 @@ describe('runCli', () => {
       await expect(runCli(['unknown-command'])).rejects.toThrow('process.exit(1)');
       expect(
         consoleLogs.some((l) =>
-          l.includes('Usage: omcustom-team [init|todo|report|recommend|sessions]'),
+          l.includes('Usage: omcustom-team [init|todo|report|recommend|sessions|doctor]'),
         ),
       ).toBe(true);
       expect(processExitCode).toBe(1);
@@ -71,7 +71,7 @@ describe('runCli', () => {
       await expect(runCli([])).rejects.toThrow('process.exit(1)');
       expect(
         consoleLogs.some((l) =>
-          l.includes('Usage: omcustom-team [init|todo|report|recommend|sessions]'),
+          l.includes('Usage: omcustom-team [init|todo|report|recommend|sessions|doctor]'),
         ),
       ).toBe(true);
       expect(processExitCode).toBe(1);

--- a/src/__tests__/doctor.test.ts
+++ b/src/__tests__/doctor.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+function makeTempDir(): string {
+  const dir = join(tmpdir(), `doctor-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function cleanup(dir: string): void {
+  try {
+    rmSync(dir, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+}
+
+describe('runDoctor', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  it('--config check passes with valid team.yaml', async () => {
+    const { runDoctor } = await import('../doctor');
+    mkdirSync(join(tmpDir, '.claude', 'team'), { recursive: true });
+    writeFileSync(
+      join(tmpDir, '.claude', 'team', 'team.yaml'),
+      'team:\n  name: test\n  version: "1.0"\n  members:\n    - github: user1\n      name: User 1\n      role: admin\n      domains: []\n',
+      'utf-8',
+    );
+
+    const results = await runDoctor({ config: true }, tmpDir);
+
+    const configResult = results.find((r) => r.check === 'team.yaml');
+    expect(configResult?.status).toBe('pass');
+  });
+
+  it('--config check fails when team.yaml missing', async () => {
+    const { runDoctor } = await import('../doctor');
+
+    const results = await runDoctor({ config: true }, tmpDir);
+
+    const configResult = results.find((r) => r.check === 'team.yaml');
+    expect(configResult?.status).toBe('fail');
+  });
+
+  it('--stewards check detects coverage gaps', async () => {
+    const { runDoctor } = await import('../doctor');
+    mkdirSync(join(tmpDir, '.claude', 'team'), { recursive: true });
+    writeFileSync(
+      join(tmpDir, '.claude', 'team', 'STEWARDS.yaml'),
+      'stewards:\n  version: "1.0"\n  domains:\n    backend:\n      primary: user1\n      backup: null\n      paths:\n        - src/api/**\n',
+      'utf-8',
+    );
+
+    const results = await runDoctor({ stewards: true }, tmpDir);
+
+    const gapResult = results.find((r) => r.check === 'steward-coverage');
+    expect(gapResult?.status).toBe('warn');
+    expect(gapResult?.message).toContain('backend');
+  });
+
+  it('--stewards check passes with full coverage', async () => {
+    const { runDoctor } = await import('../doctor');
+    mkdirSync(join(tmpDir, '.claude', 'team'), { recursive: true });
+    writeFileSync(
+      join(tmpDir, '.claude', 'team', 'STEWARDS.yaml'),
+      'stewards:\n  version: "1.0"\n  domains:\n    backend:\n      primary: user1\n      backup: user2\n      paths:\n        - src/api/**\n',
+      'utf-8',
+    );
+
+    const results = await runDoctor({ stewards: true }, tmpDir);
+
+    const gapResult = results.find((r) => r.check === 'steward-coverage');
+    expect(gapResult?.status).toBe('pass');
+  });
+
+  it('--locks check detects modified locked files', async () => {
+    const { runDoctor } = await import('../doctor');
+    const { LockfileManager } = await import('../lockfile');
+
+    mkdirSync(join(tmpDir, '.claude', 'team'), { recursive: true });
+    const teamYaml = join(tmpDir, '.claude', 'team', 'team.yaml');
+    writeFileSync(teamYaml, 'team: original\n', 'utf-8');
+
+    const lockMgr = new LockfileManager(tmpDir);
+    lockMgr.lock(teamYaml);
+
+    // Modify the file
+    writeFileSync(teamYaml, 'team: modified\n', 'utf-8');
+
+    const results = await runDoctor({ locks: true }, tmpDir);
+
+    const lockResult = results.find((r) => r.check === 'file-integrity');
+    expect(lockResult?.status).toBe('fail');
+  });
+
+  it('--locks check passes when no modifications', async () => {
+    const { runDoctor } = await import('../doctor');
+    const { LockfileManager } = await import('../lockfile');
+
+    mkdirSync(join(tmpDir, '.claude', 'team'), { recursive: true });
+    const teamYaml = join(tmpDir, '.claude', 'team', 'team.yaml');
+    writeFileSync(teamYaml, 'team: original\n', 'utf-8');
+
+    const lockMgr = new LockfileManager(tmpDir);
+    lockMgr.lock(teamYaml);
+
+    const results = await runDoctor({ locks: true }, tmpDir);
+
+    const lockResult = results.find((r) => r.check === 'file-integrity');
+    expect(lockResult?.status).toBe('pass');
+  });
+
+  it('returns all checks when no flags specified', async () => {
+    const { runDoctor } = await import('../doctor');
+
+    const results = await runDoctor({}, tmpDir);
+
+    // Should run at least config, stewards, and locks checks
+    expect(results.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('--updates check shows update available', async () => {
+    const vcModule = await import('../version-checker');
+    const spy = spyOn(vcModule, 'checkForUpdate').mockResolvedValue({
+      current: '0.8.0',
+      latest: '0.9.0',
+      updateAvailable: true,
+    });
+
+    const { runDoctor } = await import('../doctor');
+    const results = await runDoctor({ updates: true }, tmpDir);
+
+    const r = results.find((r) => r.check === 'updates');
+    expect(r?.status).toBe('warn');
+    expect(r?.message).toContain('0.9.0');
+    spy.mockRestore();
+  });
+
+  it('--updates check shows up to date', async () => {
+    const vcModule = await import('../version-checker');
+    const spy = spyOn(vcModule, 'checkForUpdate').mockResolvedValue({
+      current: '0.8.0',
+      latest: '0.8.0',
+      updateAvailable: false,
+    });
+
+    const { runDoctor } = await import('../doctor');
+    const results = await runDoctor({ updates: true }, tmpDir);
+
+    const r = results.find((r) => r.check === 'updates');
+    expect(r?.status).toBe('pass');
+    spy.mockRestore();
+  });
+
+  it('--updates check handles network failure gracefully', async () => {
+    const vcModule = await import('../version-checker');
+    const spy = spyOn(vcModule, 'checkForUpdate').mockResolvedValue(null);
+
+    const { runDoctor } = await import('../doctor');
+    const results = await runDoctor({ updates: true }, tmpDir);
+
+    const r = results.find((r) => r.check === 'updates');
+    expect(r?.status).toBe('warn');
+    expect(r?.message).toContain('network');
+    spy.mockRestore();
+  });
+
+  it('--config check fails when team.yaml is invalid YAML', async () => {
+    const { runDoctor } = await import('../doctor');
+    mkdirSync(join(tmpDir, '.claude', 'team'), { recursive: true });
+    writeFileSync(
+      join(tmpDir, '.claude', 'team', 'team.yaml'),
+      'not: valid: team: yaml: structure\n',
+      'utf-8',
+    );
+
+    const results = await runDoctor({ config: true }, tmpDir);
+
+    const configResult = results.find((r) => r.check === 'team.yaml');
+    expect(configResult?.status).toBe('fail');
+    expect(configResult?.message).toContain('Invalid');
+  });
+
+  it('--stewards check fails when STEWARDS.yaml is invalid', async () => {
+    const { runDoctor } = await import('../doctor');
+    mkdirSync(join(tmpDir, '.claude', 'team'), { recursive: true });
+    writeFileSync(
+      join(tmpDir, '.claude', 'team', 'STEWARDS.yaml'),
+      'not_stewards: true\n',
+      'utf-8',
+    );
+
+    const results = await runDoctor({ stewards: true }, tmpDir);
+
+    const stewardsResult = results.find((r) => r.check === 'STEWARDS.yaml');
+    expect(stewardsResult?.status).toBe('fail');
+    expect(stewardsResult?.message).toContain('Invalid');
+  });
+});

--- a/src/__tests__/doctor.test.ts
+++ b/src/__tests__/doctor.test.ts
@@ -125,7 +125,11 @@ describe('runDoctor', () => {
 
     const results = await runDoctor({}, tmpDir);
 
-    // Should run at least config, stewards, and locks checks
+    // runAll runs config, stewards, and locks — but NOT updates (opt-in only, requires network)
+    const checkNames = results.map((r) => r.check);
+    expect(checkNames).toContain('team.yaml');
+    expect(checkNames).toContain('file-integrity');
+    expect(checkNames.includes('updates')).toBe(false);
     expect(results.length).toBeGreaterThanOrEqual(3);
   });
 

--- a/src/__tests__/lockfile.test.ts
+++ b/src/__tests__/lockfile.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+function makeTempDir(): string {
+  const dir = join(tmpdir(), `lockfile-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function cleanup(dir: string): void {
+  try {
+    rmSync(dir, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+}
+
+describe('LockfileManager', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+    mkdirSync(join(tmpDir, '.claude', 'team'), { recursive: true });
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  it('lock() creates .lockfile.json with correct hash', async () => {
+    const { LockfileManager } = await import('../lockfile');
+    const filePath = join(tmpDir, '.claude', 'team', 'team.yaml');
+    writeFileSync(filePath, 'team: test\n', 'utf-8');
+    const manager = new LockfileManager(tmpDir);
+    manager.lock(filePath);
+    const lockfilePath = join(tmpDir, '.claude', 'team', '.lockfile.json');
+    expect(existsSync(lockfilePath)).toBe(true);
+    const lockData = JSON.parse(readFileSync(lockfilePath, 'utf-8'));
+    // toHaveProperty treats '.' as path separator, so check key existence directly
+    expect(Object.hasOwn(lockData, filePath)).toBe(true);
+    expect(lockData[filePath].hash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('verify() returns ok: true for unchanged file', async () => {
+    const { LockfileManager } = await import('../lockfile');
+    const filePath = join(tmpDir, '.claude', 'team', 'team.yaml');
+    writeFileSync(filePath, 'team: test\n', 'utf-8');
+    const manager = new LockfileManager(tmpDir);
+    manager.lock(filePath);
+    const result = manager.verify(filePath);
+    expect(result.ok).toBe(true);
+  });
+
+  it('verify() returns ok: false for modified file', async () => {
+    const { LockfileManager } = await import('../lockfile');
+    const filePath = join(tmpDir, '.claude', 'team', 'team.yaml');
+    writeFileSync(filePath, 'team: test\n', 'utf-8');
+    const manager = new LockfileManager(tmpDir);
+    manager.lock(filePath);
+    writeFileSync(filePath, 'team: modified\n', 'utf-8');
+    const result = manager.verify(filePath);
+    expect(result.ok).toBe(false);
+    expect(result).toHaveProperty('expected');
+    expect(result).toHaveProperty('actual');
+  });
+
+  it('unlock() removes entry from lockfile', async () => {
+    const { LockfileManager } = await import('../lockfile');
+    const filePath = join(tmpDir, '.claude', 'team', 'team.yaml');
+    writeFileSync(filePath, 'team: test\n', 'utf-8');
+    const manager = new LockfileManager(tmpDir);
+    manager.lock(filePath);
+    manager.unlock(filePath);
+    const result = manager.verify(filePath);
+    expect(result.ok).toBe(true);
+  });
+
+  it('verifyAll() checks all locked paths', async () => {
+    const { LockfileManager } = await import('../lockfile');
+    const file1 = join(tmpDir, '.claude', 'team', 'team.yaml');
+    const file2 = join(tmpDir, '.claude', 'team', 'STEWARDS.yaml');
+    writeFileSync(file1, 'team: test\n', 'utf-8');
+    writeFileSync(file2, 'stewards: test\n', 'utf-8');
+    const manager = new LockfileManager(tmpDir);
+    manager.lock(file1);
+    manager.lock(file2);
+    writeFileSync(file2, 'stewards: changed\n', 'utf-8');
+    const results = manager.verifyAll();
+    expect(results.length).toBe(2);
+    const okResults: typeof results = [];
+    const failResults: typeof results = [];
+    for (const r of results) {
+      if (r.ok) okResults.push(r);
+      else failResults.push(r);
+    }
+    expect(okResults.length).toBe(1);
+    expect(failResults.length).toBe(1);
+  });
+
+  it('handles missing .lockfile.json gracefully', async () => {
+    const { LockfileManager } = await import('../lockfile');
+    const manager = new LockfileManager(tmpDir);
+    const result = manager.verifyAll();
+    expect(result).toEqual([]);
+  });
+
+  it('handles missing locked file gracefully', async () => {
+    const { LockfileManager } = await import('../lockfile');
+    const filePath = join(tmpDir, '.claude', 'team', 'team.yaml');
+    writeFileSync(filePath, 'team: test\n', 'utf-8');
+    const manager = new LockfileManager(tmpDir);
+    manager.lock(filePath);
+    rmSync(filePath);
+    const result = manager.verify(filePath);
+    expect(result.ok).toBe(false);
+  });
+
+  it('lock is idempotent (lock same file twice updates hash)', async () => {
+    const { LockfileManager } = await import('../lockfile');
+    const filePath = join(tmpDir, '.claude', 'team', 'team.yaml');
+    writeFileSync(filePath, 'team: v1\n', 'utf-8');
+    const manager = new LockfileManager(tmpDir);
+    manager.lock(filePath);
+    writeFileSync(filePath, 'team: v2\n', 'utf-8');
+    manager.lock(filePath);
+    const result = manager.verify(filePath);
+    expect(result.ok).toBe(true);
+  });
+});

--- a/src/__tests__/version-checker.test.ts
+++ b/src/__tests__/version-checker.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+
+describe('checkForUpdate', () => {
+  let fetchSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = spyOn(globalThis, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it('returns updateAvailable: true when registry version is newer', async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ version: '1.0.0' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const { checkForUpdate } = await import('../version-checker');
+    const result = await checkForUpdate('test-pkg', '0.7.2');
+    expect(result).toEqual({ current: '0.7.2', latest: '1.0.0', updateAvailable: true });
+  });
+
+  it('returns updateAvailable: false when at latest version', async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ version: '0.7.2' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const { checkForUpdate } = await import('../version-checker');
+    const result = await checkForUpdate('test-pkg', '0.7.2');
+    expect(result).toEqual({ current: '0.7.2', latest: '0.7.2', updateAvailable: false });
+  });
+
+  it('returns null on fetch failure', async () => {
+    fetchSpy.mockRejectedValue(new Error('Network error'));
+    const { checkForUpdate } = await import('../version-checker');
+    const result = await checkForUpdate('test-pkg', '0.7.2');
+    expect(result).toBeNull();
+  });
+
+  it('returns null on non-200 response', async () => {
+    fetchSpy.mockResolvedValue(new Response('Not found', { status: 404 }));
+    const { checkForUpdate } = await import('../version-checker');
+    const result = await checkForUpdate('test-pkg', '0.7.2');
+    expect(result).toBeNull();
+  });
+
+  it('returns null on malformed JSON', async () => {
+    fetchSpy.mockResolvedValue(
+      new Response('not json', { status: 200, headers: { 'Content-Type': 'text/plain' } }),
+    );
+    const { checkForUpdate } = await import('../version-checker');
+    const result = await checkForUpdate('test-pkg', '0.7.2');
+    expect(result).toBeNull();
+  });
+
+  it('sanitizes version string (strips non-semver chars)', async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ version: '1.0.0\x1b[31m' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const { checkForUpdate } = await import('../version-checker');
+    const result = await checkForUpdate('test-pkg', '0.7.2');
+    expect(result?.latest).toBe('1.0.0');
+    expect(result?.updateAvailable).toBe(true);
+  });
+});
+
+describe('compareSemver', () => {
+  it('correctly compares major versions', async () => {
+    const { compareSemver } = await import('../version-checker');
+    expect(compareSemver('2.0.0', '1.0.0')).toBeGreaterThan(0);
+    expect(compareSemver('1.0.0', '2.0.0')).toBeLessThan(0);
+  });
+
+  it('correctly compares minor versions', async () => {
+    const { compareSemver } = await import('../version-checker');
+    expect(compareSemver('1.1.0', '1.0.0')).toBeGreaterThan(0);
+  });
+
+  it('correctly compares patch versions', async () => {
+    const { compareSemver } = await import('../version-checker');
+    expect(compareSemver('1.0.1', '1.0.0')).toBeGreaterThan(0);
+  });
+
+  it('returns 0 for equal versions', async () => {
+    const { compareSemver } = await import('../version-checker');
+    expect(compareSemver('1.0.0', '1.0.0')).toBe(0);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,6 @@
 import type { AgentCategory } from './agent-catalog';
 import { initTeam } from './init';
+import { TEAM_PATHS } from './paths';
 import { TeamTodo } from './team-todo';
 
 export async function runCli(args: string[]): Promise<void> {
@@ -78,7 +79,7 @@ export async function runCli(args: string[]): Promise<void> {
             process.exit(1);
           }
           if (!todo.exists()) {
-            TeamTodo.createTemplate('.claude/team/TODO.md');
+            TeamTodo.createTemplate(TEAM_PATHS.TODO_MD);
           } else {
             todo.load();
           }
@@ -104,7 +105,7 @@ export async function runCli(args: string[]): Promise<void> {
       const { SessionLogger } = await import('./session-logger');
       const { existsSync } = await import('node:fs');
       const { resolve } = await import('node:path');
-      const dbPath = resolve('.', '.claude/team/sessions.db');
+      const dbPath = resolve('.', TEAM_PATHS.SESSIONS_DB);
 
       if (!existsSync(dbPath)) {
         console.log('No sessions database found. Run some Claude Code sessions first.');
@@ -196,8 +197,8 @@ export async function runCli(args: string[]): Promise<void> {
 
       const { existsSync } = await import('node:fs');
       const { resolve } = await import('node:path');
-      const sessionsDbPath = existsSync(resolve('.', '.claude/team/sessions.db'))
-        ? resolve('.', '.claude/team/sessions.db')
+      const sessionsDbPath = existsSync(resolve('.', TEAM_PATHS.SESSIONS_DB))
+        ? resolve('.', TEAM_PATHS.SESSIONS_DB)
         : undefined;
 
       const recommendations = recommender.recommend({ minConfidence, category, sessionsDbPath });
@@ -225,8 +226,30 @@ export async function runCli(args: string[]): Promise<void> {
       }
       break;
     }
+    case 'doctor': {
+      const { runDoctor } = await import('./doctor');
+      const checks = {
+        config: args.includes('--config'),
+        stewards: args.includes('--stewards'),
+        updates: args.includes('--updates'),
+        locks: args.includes('--locks'),
+      };
+
+      const results = await runDoctor(checks);
+
+      for (const r of results) {
+        const icon = r.status === 'pass' ? '\u2713' : r.status === 'warn' ? '!' : '\u2717';
+        console.log(`${icon} [${r.check}] ${r.message}`);
+      }
+
+      const hasFailure = results.some((r) => r.status === 'fail');
+      if (hasFailure) {
+        process.exit(1);
+      }
+      break;
+    }
     default: {
-      console.log('Usage: omcustom-team [init|todo|report|recommend|sessions]');
+      console.log('Usage: omcustom-team [init|todo|report|recommend|sessions|doctor]');
       console.log('');
       console.log('Commands:');
       console.log('  init [--yes|-y]    Initialize team configuration');
@@ -251,6 +274,12 @@ export async function runCli(args: string[]): Promise<void> {
       console.log('    --search, -s <term>  Search in summary/branch/user');
       console.log('    --user, -u <name>    Filter by user');
       console.log('    --limit, -l <n>      Max results (default: 20)');
+      console.log('');
+      console.log('Doctor options:');
+      console.log('    --config             Validate team.yaml');
+      console.log('    --stewards           Check steward coverage');
+      console.log('    --updates            Check for newer version');
+      console.log('    --locks              Verify file integrity');
       process.exit(1);
     }
   }

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -45,6 +45,8 @@ export async function runDoctor(
     results.push(...checkLocks(basePath));
   }
 
+  // --updates is opt-in only (not included in runAll) because it makes
+  // a network call to npm registry. Avoid slowing down local health checks.
   if (options.updates) {
     const updateResult = await checkUpdates();
     if (updateResult) {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -1,0 +1,210 @@
+/**
+ * Team health check framework.
+ * Aggregates validation from TeamConfig, Stewards, and LockfileManager.
+ */
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { LockfileManager } from './lockfile';
+import { TEAM_PATHS } from './paths';
+import { Stewards } from './stewards';
+import { TeamConfig } from './team-config';
+import { checkForUpdate } from './version-checker';
+
+export interface DoctorCheckResult {
+  check: string;
+  status: 'pass' | 'warn' | 'fail';
+  message: string;
+}
+
+export interface DoctorOptions {
+  config?: boolean;
+  stewards?: boolean;
+  updates?: boolean;
+  locks?: boolean;
+}
+
+const PACKAGE_NAME = '@oh-my-customcode/oh-my-teammates';
+const CURRENT_VERSION = '0.8.0';
+
+export async function runDoctor(
+  options: DoctorOptions,
+  basePath = '.',
+): Promise<DoctorCheckResult[]> {
+  const results: DoctorCheckResult[] = [];
+  const runAll = !options.config && !options.stewards && !options.updates && !options.locks;
+
+  if (runAll || options.config) {
+    results.push(...checkConfig(basePath));
+  }
+
+  if (runAll || options.stewards) {
+    results.push(...checkStewards(basePath));
+  }
+
+  if (runAll || options.locks) {
+    results.push(...checkLocks(basePath));
+  }
+
+  if (options.updates) {
+    const updateResult = await checkUpdates();
+    if (updateResult) {
+      results.push(updateResult);
+    }
+  }
+
+  return results;
+}
+
+function checkConfig(basePath: string): DoctorCheckResult[] {
+  const results: DoctorCheckResult[] = [];
+  const teamYamlPath = join(basePath, TEAM_PATHS.TEAM_YAML);
+
+  if (!existsSync(teamYamlPath)) {
+    results.push({
+      check: 'team.yaml',
+      status: 'fail',
+      message: `${TEAM_PATHS.TEAM_YAML} not found. Run 'omcustom-team init' first.`,
+    });
+    return results;
+  }
+
+  try {
+    const config = new TeamConfig(teamYamlPath);
+    const data = config.load();
+    results.push({
+      check: 'team.yaml',
+      status: 'pass',
+      message: `Valid (${data.team.members.length} members)`,
+    });
+  } catch (err) {
+    results.push({
+      check: 'team.yaml',
+      status: 'fail',
+      message: `Invalid: ${err instanceof Error ? err.message : String(err)}`,
+    });
+  }
+
+  return results;
+}
+
+function checkStewards(basePath: string): DoctorCheckResult[] {
+  const results: DoctorCheckResult[] = [];
+  const stewardsPath = join(basePath, TEAM_PATHS.STEWARDS_YAML);
+
+  if (!existsSync(stewardsPath)) {
+    results.push({
+      check: 'STEWARDS.yaml',
+      status: 'fail',
+      message: `${TEAM_PATHS.STEWARDS_YAML} not found. Run 'omcustom-team init' first.`,
+    });
+    return results;
+  }
+
+  try {
+    const stewards = new Stewards(stewardsPath);
+    stewards.load();
+    const domains = stewards.getDomains();
+
+    results.push({
+      check: 'STEWARDS.yaml',
+      status: 'pass',
+      message: `Valid (${Object.keys(domains).length} domains)`,
+    });
+
+    // Check coverage gaps — use for loop for Linux coverage
+    const gaps: string[] = [];
+    for (const [domain, steward] of Object.entries(domains)) {
+      if (steward.backup === null) {
+        gaps.push(domain);
+      }
+    }
+
+    if (gaps.length > 0) {
+      results.push({
+        check: 'steward-coverage',
+        status: 'warn',
+        message: `${gaps.length} domain(s) without backup steward: ${gaps.join(', ')}`,
+      });
+    } else {
+      results.push({
+        check: 'steward-coverage',
+        status: 'pass',
+        message: 'All domains have backup stewards',
+      });
+    }
+  } catch (err) {
+    results.push({
+      check: 'STEWARDS.yaml',
+      status: 'fail',
+      message: `Invalid: ${err instanceof Error ? err.message : String(err)}`,
+    });
+  }
+
+  return results;
+}
+
+function checkLocks(basePath: string): DoctorCheckResult[] {
+  const manager = new LockfileManager(basePath);
+  const verifyResults = manager.verifyAll();
+
+  if (verifyResults.length === 0) {
+    return [
+      {
+        check: 'file-integrity',
+        status: 'pass',
+        message: 'No locked files to verify',
+      },
+    ];
+  }
+
+  const failures: string[] = [];
+  for (const r of verifyResults) {
+    if (!r.ok) {
+      failures.push(r.path);
+    }
+  }
+
+  if (failures.length > 0) {
+    return [
+      {
+        check: 'file-integrity',
+        status: 'fail',
+        message: `${failures.length} file(s) modified since lock: ${failures.map((f) => f.split('/').pop() ?? f).join(', ')}`,
+      },
+    ];
+  }
+
+  return [
+    {
+      check: 'file-integrity',
+      status: 'pass',
+      message: `All ${verifyResults.length} locked file(s) intact`,
+    },
+  ];
+}
+
+async function checkUpdates(): Promise<DoctorCheckResult | null> {
+  const result = await checkForUpdate(PACKAGE_NAME, CURRENT_VERSION);
+
+  if (result === null) {
+    return {
+      check: 'updates',
+      status: 'warn',
+      message: 'Could not check for updates (network unavailable or timeout)',
+    };
+  }
+
+  if (result.updateAvailable) {
+    return {
+      check: 'updates',
+      status: 'warn',
+      message: `Update available: ${result.current} → ${result.latest}`,
+    };
+  }
+
+  return {
+    check: 'updates',
+    status: 'pass',
+    message: `Up to date (${result.current})`,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,13 @@ export {
   getCatalogByCategory,
   getCatalogEntry,
 } from './agent-catalog';
+export type { DoctorCheckResult, DoctorOptions } from './doctor';
+export { runDoctor } from './doctor';
+export type { LockEntry, VerifyResult } from './lockfile';
+export { LockfileManager } from './lockfile';
 export type { ParsedDependencies } from './manifest-parser';
 export { parseManifest } from './manifest-parser';
+export { TEAM_DIR, TEAM_PATHS } from './paths';
 export type { AgentRecommendation } from './recommender';
 export { Recommender } from './recommender';
 export { ReportGenerator } from './report';
@@ -15,3 +20,5 @@ export { Stewards } from './stewards';
 export { TeamConfig } from './team-config';
 export type { TodoItem } from './team-todo';
 export { TeamTodo } from './team-todo';
+export type { UpdateCheckResult } from './version-checker';
+export { checkForUpdate, compareSemver } from './version-checker';

--- a/src/init.ts
+++ b/src/init.ts
@@ -12,6 +12,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { basename, extname, join } from 'node:path';
+import { TEAM_DIR, TEAM_PATHS } from './paths';
 import { DEFAULT_DOMAINS, Stewards } from './stewards';
 import { TeamConfig } from './team-config';
 
@@ -284,7 +285,7 @@ export function scaffoldClaudeMd(
  * @param analysisSkillAvailable - When true, a note about the /analysis skill is appended to TODO.md.
  */
 export function scaffoldTeamDir(rootDir = '.', analysisSkillAvailable = false): void {
-  const teamDir = join(rootDir, '.claude', 'team');
+  const teamDir = join(rootDir, TEAM_DIR);
   mkdirSync(teamDir, { recursive: true });
 
   const todoPath = join(teamDir, 'TODO.md');
@@ -326,10 +327,10 @@ export function scaffoldTeamDir(rootDir = '.', analysisSkillAvailable = false): 
  */
 export function migrateTeamFiles(rootDir = '.'): string[] {
   const moved: string[] = [];
-  const teamDir = join(rootDir, '.claude', 'team');
+  const teamDir = join(rootDir, TEAM_DIR);
   const migrations: Array<[string, string]> = [
-    [join(rootDir, 'team.yaml'), join(teamDir, 'team.yaml')],
-    [join(rootDir, 'STEWARDS.yaml'), join(teamDir, 'STEWARDS.yaml')],
+    [join(rootDir, 'team.yaml'), join(rootDir, TEAM_PATHS.TEAM_YAML)],
+    [join(rootDir, 'STEWARDS.yaml'), join(rootDir, TEAM_PATHS.STEWARDS_YAML)],
   ];
   for (const [src, dest] of migrations) {
     if (existsSync(src) && !existsSync(dest)) {
@@ -373,14 +374,14 @@ export async function initTeam(rootDir = '.'): Promise<{
   scaffoldTeamDir(rootDir, scanResult.analysisSkillAvailable);
 
   // 4. Create team.yaml template if it doesn't exist
-  const teamConfigPath = join(rootDir, '.claude', 'team', 'team.yaml');
+  const teamConfigPath = join(rootDir, TEAM_PATHS.TEAM_YAML);
   if (!existsSync(teamConfigPath)) {
     const projectName = detectProjectName(rootDir);
     TeamConfig.createTemplate(teamConfigPath, projectName);
   }
 
   // 5. Create STEWARDS.yaml draft based on scan results
-  const stewardsPath = join(rootDir, '.claude', 'team', 'STEWARDS.yaml');
+  const stewardsPath = join(rootDir, TEAM_PATHS.STEWARDS_YAML);
   if (!existsSync(stewardsPath)) {
     Stewards.createTemplate(stewardsPath);
   }
@@ -390,11 +391,21 @@ export async function initTeam(rootDir = '.'): Promise<{
   const claudeMdPath = join(rootDir, 'CLAUDE.md');
   const claudeMdResult = scaffoldClaudeMd(rootDir, projectName);
 
+  // 7. Register critical team files in lockfile
+  const { LockfileManager } = await import('./lockfile');
+  const lockMgr = new LockfileManager(rootDir);
+  if (existsSync(teamConfigPath)) {
+    lockMgr.lock(teamConfigPath);
+  }
+  if (existsSync(stewardsPath)) {
+    lockMgr.lock(stewardsPath);
+  }
+
   return {
     scanResult,
     teamConfigPath,
     stewardsPath,
-    teamDirPath: join(rootDir, '.claude', 'team'),
+    teamDirPath: join(rootDir, TEAM_DIR),
     claudeMdPath,
     claudeMdResult,
   };

--- a/src/lockfile.ts
+++ b/src/lockfile.ts
@@ -1,0 +1,82 @@
+/**
+ * Checksum-based file protection for team configuration files.
+ * Tracks SHA-256 hashes of critical files to detect accidental overwrites.
+ */
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { TEAM_PATHS } from './paths';
+
+export interface LockEntry {
+  hash: string;
+  lockedAt: string;
+}
+
+export interface VerifyResult {
+  path: string;
+  ok: boolean;
+  expected?: string;
+  actual?: string;
+}
+
+type LockData = Record<string, LockEntry>;
+
+export class LockfileManager {
+  private lockfilePath: string;
+
+  constructor(basePath = '.') {
+    this.lockfilePath = join(basePath, TEAM_PATHS.LOCKFILE);
+  }
+
+  private computeHash(filePath: string): string {
+    const content = readFileSync(filePath, 'utf-8');
+    return createHash('sha256').update(content).digest('hex');
+  }
+
+  private readLockData(): LockData {
+    if (!existsSync(this.lockfilePath)) return {};
+    try {
+      return JSON.parse(readFileSync(this.lockfilePath, 'utf-8')) as LockData;
+    } catch {
+      return {};
+    }
+  }
+
+  private writeLockData(data: LockData): void {
+    writeFileSync(this.lockfilePath, JSON.stringify(data, null, 2), 'utf-8');
+  }
+
+  lock(filePath: string): void {
+    const data = this.readLockData();
+    data[filePath] = { hash: this.computeHash(filePath), lockedAt: new Date().toISOString() };
+    this.writeLockData(data);
+  }
+
+  verify(filePath: string): VerifyResult {
+    const data = this.readLockData();
+    const entry = data[filePath];
+    if (!entry) return { path: filePath, ok: true };
+    if (!existsSync(filePath)) {
+      return { path: filePath, ok: false, expected: entry.hash, actual: '(file missing)' };
+    }
+    const currentHash = this.computeHash(filePath);
+    if (currentHash === entry.hash) return { path: filePath, ok: true };
+    return { path: filePath, ok: false, expected: entry.hash, actual: currentHash };
+  }
+
+  /** Uses for loop instead of .filter() for Linux coverage. */
+  verifyAll(): VerifyResult[] {
+    const data = this.readLockData();
+    const results: VerifyResult[] = [];
+    for (const filePath of Object.keys(data)) {
+      results.push(this.verify(filePath));
+    }
+    return results;
+  }
+
+  unlock(filePath: string): void {
+    const data = this.readLockData();
+    delete data[filePath];
+    this.writeLockData(data);
+  }
+}

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,0 +1,17 @@
+/**
+ * Centralized path constants for team directory structure.
+ * All team-related file paths derive from TEAM_DIR.
+ */
+
+export const TEAM_DIR = '.claude/team' as const;
+
+export const TEAM_PATHS = {
+  TEAM_YAML: `${TEAM_DIR}/team.yaml`,
+  STEWARDS_YAML: `${TEAM_DIR}/STEWARDS.yaml`,
+  TODO_MD: `${TEAM_DIR}/TODO.md`,
+  SESSIONS_DB: `${TEAM_DIR}/sessions.db`,
+  REPORT_HTML: `${TEAM_DIR}/report.html`,
+  LOCKFILE: `${TEAM_DIR}/.lockfile.json`,
+} as const;
+
+export type TeamPathKey = keyof typeof TEAM_PATHS;

--- a/src/report-template.ts
+++ b/src/report-template.ts
@@ -3,7 +3,7 @@
  * Produces a self-contained, inline-CSS HTML report (no external resources)
  */
 
-const VERSION = '0.5.0';
+const VERSION = '0.8.0';
 
 export interface ReportData {
   generatedAt: string;

--- a/src/report.ts
+++ b/src/report.ts
@@ -4,7 +4,7 @@
  */
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
-
+import { TEAM_PATHS } from './paths';
 import type { ReportData } from './report-template';
 import { generateReportHtml } from './report-template';
 import { SessionLogger } from './session-logger';
@@ -28,7 +28,7 @@ export class ReportGenerator {
   }
 
   async generate(options: ReportOptions = {}): Promise<string> {
-    const outputPath = resolve(this.basePath, options.output ?? '.claude/team/report.html');
+    const outputPath = resolve(this.basePath, options.output ?? TEAM_PATHS.REPORT_HTML);
     const days = options.days;
 
     // 1. Collect data from all sources (graceful fallback)
@@ -86,7 +86,7 @@ export class ReportGenerator {
   // ── Private data collectors ───────────────────────────────────────────────
 
   private collectTeamConfig(): { name: string; members: ReportData['members'] } | null {
-    const configPath = resolve(this.basePath, '.claude/team/team.yaml');
+    const configPath = resolve(this.basePath, TEAM_PATHS.TEAM_YAML);
     try {
       const config = new TeamConfig(configPath);
       if (!config.exists()) {
@@ -108,7 +108,7 @@ export class ReportGenerator {
   }
 
   private collectDomains(): ReportData['domains'] | null {
-    const stewardsPath = resolve(this.basePath, '.claude/team/STEWARDS.yaml');
+    const stewardsPath = resolve(this.basePath, TEAM_PATHS.STEWARDS_YAML);
     try {
       const stewards = new Stewards(stewardsPath);
       if (!stewards.exists()) {
@@ -131,7 +131,7 @@ export class ReportGenerator {
   }
 
   private collectTodos(): TodoItem[] | null {
-    const todoPath = resolve(this.basePath, '.claude/team/TODO.md');
+    const todoPath = resolve(this.basePath, TEAM_PATHS.TODO_MD);
     try {
       const todo = new TeamTodo(todoPath);
       if (!todo.exists()) {
@@ -167,7 +167,7 @@ export class ReportGenerator {
     branchDistribution: ReportData['branchDistribution'];
     recentSessions: ReportData['recentSessions'];
   } | null {
-    const dbPath = resolve(this.basePath, '.claude/team/sessions.db');
+    const dbPath = resolve(this.basePath, TEAM_PATHS.SESSIONS_DB);
     let logger: SessionLogger | null = null;
     try {
       if (!existsSync(dbPath)) {

--- a/src/session-logger.ts
+++ b/src/session-logger.ts
@@ -4,6 +4,7 @@
  */
 import { Database } from 'bun:sqlite';
 import { randomUUID } from 'node:crypto';
+import { TEAM_PATHS } from './paths';
 
 export interface Session {
   id: string;
@@ -49,7 +50,7 @@ export class SessionLogger {
   private db: Database;
   private currentSession: string | null = null;
 
-  constructor(dbPath = '.claude/team/sessions.db') {
+  constructor(dbPath: string = TEAM_PATHS.SESSIONS_DB) {
     this.db = new Database(dbPath, { create: true });
     this.db.exec('PRAGMA journal_mode=WAL');
     this.initSchema();

--- a/src/stewards.ts
+++ b/src/stewards.ts
@@ -5,6 +5,7 @@ import { dirname } from 'node:path';
  * STEWARDS.yaml -> CODEOWNERS auto-generation
  */
 import { parse, stringify } from 'yaml';
+import { TEAM_PATHS } from './paths';
 
 export interface DomainSteward {
   primary: string;
@@ -92,7 +93,7 @@ export class Stewards {
   private configPath: string;
   private data: StewardsData | null = null;
 
-  constructor(configPath = 'STEWARDS.yaml') {
+  constructor(configPath: string = TEAM_PATHS.STEWARDS_YAML) {
     this.configPath = configPath;
   }
 

--- a/src/team-config.ts
+++ b/src/team-config.ts
@@ -4,6 +4,7 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs';
  * Reads and manages team.yaml for member mapping
  */
 import { parse, stringify } from 'yaml';
+import { TEAM_PATHS } from './paths';
 
 export interface TeamMember {
   github: string;
@@ -24,7 +25,7 @@ export class TeamConfig {
   private configPath: string;
   private data: TeamConfigData | null = null;
 
-  constructor(configPath = 'team.yaml') {
+  constructor(configPath: string = TEAM_PATHS.TEAM_YAML) {
     this.configPath = configPath;
   }
 

--- a/src/team-todo.ts
+++ b/src/team-todo.ts
@@ -1,5 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
+import { TEAM_PATHS } from './paths';
 import { Stewards } from './stewards';
 
 export interface TodoItem {
@@ -94,7 +95,7 @@ export class TeamTodo {
   private items: TodoItem[] = [];
   private header: string[] = [];
 
-  constructor(todoPath = '.claude/team/TODO.md') {
+  constructor(todoPath: string = TEAM_PATHS.TODO_MD) {
     this.todoPath = todoPath;
   }
 
@@ -184,7 +185,7 @@ export class TeamTodo {
    * from STEWARDS.yaml and set it as the assignee.
    * Returns the number of items updated.
    */
-  autoAssign(stewardsPath = '.claude/team/STEWARDS.yaml'): number {
+  autoAssign(stewardsPath: string = TEAM_PATHS.STEWARDS_YAML): number {
     const stewards = new Stewards(stewardsPath);
     if (!stewards.exists()) {
       return 0;

--- a/src/version-checker.ts
+++ b/src/version-checker.ts
@@ -1,0 +1,65 @@
+/**
+ * npm registry version checker.
+ * First runtime network call in oh-my-teammates — designed for safety:
+ * - 5 second timeout
+ * - Response size bounded (reject > 10KB)
+ * - Version string sanitized (strip non-semver chars)
+ * - Graceful null return on any failure
+ */
+
+export interface UpdateCheckResult {
+  current: string;
+  latest: string;
+  updateAvailable: boolean;
+}
+
+const REGISTRY_TIMEOUT_MS = 5000;
+const MAX_RESPONSE_SIZE = 10 * 1024;
+
+export function compareSemver(a: string, b: string): number {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+function sanitizeVersion(version: string): string {
+  const match = version.match(/^(\d+\.\d+\.\d+)/);
+  return match ? (match[1] ?? '') : '';
+}
+
+export async function checkForUpdate(
+  packageName: string,
+  currentVersion: string,
+): Promise<UpdateCheckResult | null> {
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(controller.abort.bind(controller), REGISTRY_TIMEOUT_MS);
+    const response = await fetch(
+      `https://registry.npmjs.org/${encodeURIComponent(packageName)}/latest`,
+      { headers: { Accept: 'application/json' }, signal: controller.signal },
+    );
+    clearTimeout(timeoutId);
+    if (!response.ok) return null;
+    const contentLength = response.headers.get('content-length');
+    if (contentLength && Number.parseInt(contentLength, 10) > MAX_RESPONSE_SIZE) return null;
+    const text = await response.text();
+    if (text.length > MAX_RESPONSE_SIZE) return null;
+    const data: unknown = JSON.parse(text);
+    if (typeof data !== 'object' || data === null || !('version' in data)) return null;
+    const rawVersion = (data as { version: unknown }).version;
+    if (typeof rawVersion !== 'string') return null;
+    const latest = sanitizeVersion(rawVersion);
+    if (!latest) return null;
+    return {
+      current: currentVersion,
+      latest,
+      updateAvailable: compareSemver(latest, currentVersion) > 0,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/templates/.github/workflows/guardian.yml
+++ b/templates/.github/workflows/guardian.yml
@@ -105,3 +105,26 @@ jobs:
       - name: Skip team.yaml check (file absent)
         if: hashFiles('pr/.claude/team/team.yaml') == ''
         run: echo "::notice::team.yaml not present — skipping validation"
+
+      # ── Protected files integrity check ────────────────────────────────
+      - name: Verify protected file integrity
+        run: |
+          if [ -f "pr/.claude/team/.lockfile.json" ]; then
+            echo "Checking locked file integrity..."
+            cd pr
+            LOCKFILE=".claude/team/.lockfile.json"
+            FAILURES=0
+            for FILE in $(jq -r 'keys[]' "$LOCKFILE" 2>/dev/null); do
+              if [ ! -f "$FILE" ]; then
+                echo "::error::Locked file missing: $FILE"
+                FAILURES=$((FAILURES + 1))
+              fi
+            done
+            if [ "$FAILURES" -gt 0 ]; then
+              echo "::error::$FAILURES locked file(s) have issues"
+              exit 1
+            fi
+            echo "All locked files present"
+          else
+            echo "No lockfile found, skipping integrity check"
+          fi


### PR DESCRIPTION
## Summary

oh-my-customcode v0.32.0의 3가지 신규 기능(doctor --updates, session advisory, protected files)을 oh-my-teammates에 adapt합니다.

- **`src/paths.ts`**: 중앙화된 TEAM_PATHS 상수 — 7개 파일에 흩어진 18개 하드코딩 경로를 단일 소스로 통합
- **`src/version-checker.ts`**: npm 레지스트리 버전 체크 (5s timeout, 10KB response cap, version sanitization)
- **`src/lockfile.ts`**: SHA-256 체크섬 기반 파일 보호 (team.yaml, STEWARDS.yaml 무결성 검증)
- **`src/doctor.ts`**: 팀 건강 체크 프레임워크 (--config, --stewards, --updates, --locks)
- **CLI**: `omcustom-team doctor` 서브커맨드 추가
- **init**: 초기화 시 자동 lockfile 등록
- **Guardian CI**: Protected files 무결성 검증 step 추가
- **exports**: 신규 모듈 전체 라이브러리 export

## Changes

| File | Change |
|------|--------|
| `src/paths.ts` | NEW — TEAM_DIR, TEAM_PATHS constants |
| `src/version-checker.ts` | NEW — checkForUpdate(), compareSemver() |
| `src/lockfile.ts` | NEW — LockfileManager class |
| `src/doctor.ts` | NEW — runDoctor() framework |
| `src/cli.ts` | ADD doctor case + usage text |
| `src/init.ts` | ADD lockfile registration (step 7) |
| `src/index.ts` | ADD 7 new exports |
| `src/report.ts` | USE TEAM_PATHS imports |
| `src/session-logger.ts` | USE TEAM_PATHS default |
| `src/stewards.ts` | USE TEAM_PATHS default |
| `src/team-config.ts` | USE TEAM_PATHS default |
| `src/team-todo.ts` | USE TEAM_PATHS default |
| `src/report-template.ts` | UPDATE VERSION to 0.8.0 |
| `templates/.github/workflows/guardian.yml` | ADD lockfile integrity check |
| `package.json` | BUMP 0.7.2 → 0.8.0 |

## Test plan

- [x] 378 tests pass (was 348), 0 failures
- [x] 100% function coverage on all new modules
- [x] `bunx tsc --noEmit` clean
- [x] `bun run build` success
- [x] `bun run dist/cli.js doctor --locks` smoke test OK
- [ ] CI pipeline passes

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)